### PR TITLE
feat(filedb): FileDB V2/V3 parser 実装 (step 1-4)

### DIFF
--- a/docs/session_binary_investigation.md
+++ b/docs/session_binary_investigation.md
@@ -1,0 +1,112 @@
+# SessionData / BinaryData Investigation Result
+
+> 調査日: 2026-04-19．対象: ``sample.a7s`` を FileDB V3 parser で走査し，
+> ``<SessionData>`` 配下の ``<BinaryData>`` Attrib content を抽出して解析．
+
+## TL;DR
+
+**仮説 1（再帰 FileDB V3）が確定．** 外側 FileDB 内の 5 個の ``<BinaryData>`` は，
+いずれも**末尾マジック ``08000000FDFFFFFF`` を持つ完全な FileDB V3 文書**だった．
+既存の ``parser.filedb`` を**そのまま再帰適用**するだけで，島 / 建物 / 人口系の
+階層データが取得できる．
+
+## 手順
+
+1. 外側 ``data.a7s`` 解凍後の FileDB を parse
+2. タグ辞書から ``SessionData`` (id=466) と ``BinaryData`` (attrib id=33326) を解決
+3. DOM 走査中，``<SessionData>`` スコープ内の ``<BinaryData>`` attrib content を 5 件収集
+4. 各 blob を ``detect_version`` → V3 確定
+5. それぞれを再度 FileDB として ``parse_tag_section`` + ``iter_dom`` に食わせる
+
+## 5 セッションの実測値
+
+| # | サイズ | Shannon entropy (bytes) | 末尾マジック |
+|---|---|---|---|
+| 0 | 22,853,288 B | 0.411 | `08000000FDFFFFFF` ✅ |
+| 1 | 32,038,880 B | 0.707 | `08000000FDFFFFFF` ✅ |
+| 2 | 32,671,384 B | 0.879 | `08000000FDFFFFFF` ✅ |
+| 3 | 37,571,112 B | 0.496 | `08000000FDFFFFFF` ✅ |
+| 4 | 24,477,728 B | 0.552 | `08000000FDFFFFFF` ✅ |
+
+全て V3 magic 一致．entropy の低さ（0.4〜0.9 bit / byte）は DOM の反復構造（``[bytesize][id]`` の規則的なパターンと大量の 0 埋め属性）で説明がつく．追加圧縮（仮説 3）の必要なし．
+
+先頭 24 バイト共通:
+
+```
+04 00 00 00 01 80 00 00 1D 00 00 00 00 00 00 00 00 00 00 00 02 00 00 00
+└─ bytesize=4 ─┘ └─ id=0x8001 ─┘ └─ content 4B ─┘ └─ bytesize=0 ─┘ └─ id=2 ─┘
+        Attrib id=1 "SessionFileVersion?" = 29 (0x1D)      Tag "GameSessionManager"
+```
+
+5 セッションとも **同じ先頭パターン**から始まる．
+
+## Session 0 の内部構造（先頭 30 op）
+
+```
+attrib  SessionFileVersion (4B)
+tag     GameSessionManager
+  tag     MapTemplate
+    attrib  Size (8B)
+    attrib  PlayableArea (16B)
+    attrib  InitialPlayableArea (16B)
+    tag     RandomlyPlacedThirdParties
+      tag     <unknown 1>
+        tag     value
+          attrib  id (2B)
+    attrib  Filename (174B)
+    attrib  ElementCount (4B)
+    tag     TemplateElement
+      tag     Element
+        attrib  Position (8B)
+        attrib  MapFilePath (128B)
+        attrib  Rotation90 (1B)
+        attrib  IslandLabel (18B)
+        attrib  FertilityGuids (16B)
+        attrib  RandomizeFertilities (1B)
+        tag     MineSlotMapping
+          attrib  <unknown 32768> (8B)   ← 匿名 attrib (id=0x8000)
+          ...
+```
+
+## 内部辞書の構成
+
+Session 0 の場合:
+
+- Tag 辞書 = **447 件**（外側 465 件と別物．session 固有 ID）
+- Attrib 辞書 = **189 件**（外側 558 件．こちらも独立）
+- 興味深いタグ群:
+  - **104 件の ``AreaManager_*``**（動的にタグ名化された島マネージャ）
+  - **62 件の ``Island*``**（``Island9``, ``Island18``, ``Island38``, ``Island47`` など具体値）
+  - ``Building``, ``PassiveTradeBuilding``, ``AreaPopulationManager``
+  - ``MinimumStock``, ``ExclusiveTradeGood``
+
+→ 島単位の建物・人口・在庫データが完全に内部 FileDB として格納されている．
+
+## Anonymous attrib (id = 0x8000 = 32768)
+
+内部 DOM に ``<unknown 32768>`` が頻出．これは attrib 辞書に id 32768 が登録されていない
+ためフォールバック名になる．BlueByte は **無名プレースホルダ attrib として id=0x8000 を予約**
+している可能性が高い．``MineSlotMapping`` のような座標ペア配列でよく使われる．
+
+v0.2 parser は未解決 ID を ``Attrib_32768`` フォールバックで処理するため decode は止まらない．
+interpreter 層（v0.2 step 5）で「親タグが ``MineSlotMapping`` かつ attrib id=0x8000 なら
+``(u32, u32)`` ペア配列として解釈」のルールを用意すれば良い．
+
+## v0.3 実装方針（差分）
+
+もともと「本丸 / 沼」想定だった v0.3 が，**v0.2 parser の副産物で実質 80% 完了**した．
+残す主要課題:
+
+- [x] 再帰 FileDB 仮説の検証（この調査で確定）
+- [x] ``parser.filedb.session.extract_sessions(data)`` 実装（本 PR に同梱）
+- [ ] 匿名 attrib (id=0x8000) のコンテキスト依存型解釈（interpreter 層の一部）
+- [ ] 島エンティティ（``Island*`` / ``AreaManager_*`` / ``Building``）の Pydantic モデル化
+- [ ] 人口 (``AreaPopulationManager``) / 在庫 (``MinimumStock``) のスキーマ調査
+- [ ] 全 5 セッション（旧世界 / 新世界 / エンベサ / 北極 / Cape）の対応関係特定
+  - セッションの「意味」は外側の同階層 Attrib（``SessionID`` など）で参照されているはず
+
+## 参考
+
+- 上流仮説: [anno-mods/FileDBReader #33](https://github.com/anno-mods/FileDBReader/issues/33) で accountdata の未解決ノードが言及されているが，SessionData が再帰 FileDB である旨は明示されていない
+- CLAUDE.md v0.3 本丸章に記載した 3 仮説のうち **仮説 1 を本調査で確定**（仮説 2/3 は棄却）
+- 実装は ``src/anno_save_analyzer/parser/filedb/session.py`` の ``extract_sessions`` 1 本で完結

--- a/src/anno_save_analyzer/parser/filedb/__init__.py
+++ b/src/anno_save_analyzer/parser/filedb/__init__.py
@@ -1,0 +1,34 @@
+"""FileDB (BBDom) V3 parser — clean-room port of anno-mods/FileDBReader．
+
+公開 API:
+
+- ``FileDBVersion`` : V1 / V2 / V3 列挙
+- ``detect_version(data: bytes)`` : 末尾マジックから version 判定
+- ``TagDictionary`` : tag / attrib name 辞書
+- ``parse_tag_section(data, version)`` : 末尾からの辞書ペア取り出し
+- ``iter_dom(data, version)`` : streaming iterator（Tag / Attrib / Terminator イベント）
+- ``build_xml(data)`` : lxml ``Element`` ツリー構築（ワンショット．将来的に streaming 対応予定）
+"""
+
+from .dictionary import TagDictionary, TagSection, parse_tag_section
+from .dom import Attrib, DomEvent, EventKind, Tag, Terminator, iter_dom
+from .exceptions import FileDBParseError, UnsupportedFileDBVersion
+from .version import FileDBVersion, detect_version
+from .xml import build_xml
+
+__all__ = [
+    "FileDBVersion",
+    "detect_version",
+    "TagDictionary",
+    "TagSection",
+    "parse_tag_section",
+    "iter_dom",
+    "DomEvent",
+    "EventKind",
+    "Tag",
+    "Attrib",
+    "Terminator",
+    "build_xml",
+    "FileDBParseError",
+    "UnsupportedFileDBVersion",
+]

--- a/src/anno_save_analyzer/parser/filedb/__init__.py
+++ b/src/anno_save_analyzer/parser/filedb/__init__.py
@@ -13,6 +13,7 @@
 from .dictionary import TagDictionary, TagSection, parse_tag_section
 from .dom import Attrib, DomEvent, EventKind, Tag, Terminator, iter_dom
 from .exceptions import FileDBParseError, UnsupportedFileDBVersion
+from .session import extract_sessions
 from .version import FileDBVersion, detect_version
 from .xml import build_xml
 
@@ -29,6 +30,7 @@ __all__ = [
     "Attrib",
     "Terminator",
     "build_xml",
+    "extract_sessions",
     "FileDBParseError",
     "UnsupportedFileDBVersion",
 ]

--- a/src/anno_save_analyzer/parser/filedb/dictionary.py
+++ b/src/anno_save_analyzer/parser/filedb/dictionary.py
@@ -1,0 +1,102 @@
+"""Tag / Attrib 名の辞書 decode．
+
+V2 / V3 の辞書フォーマット（``ParseDictionary`` 参照）::
+
+    [Count: int32 LE]
+    [ID_0: uint16 LE]
+    [ID_1: uint16 LE]
+    ...
+    [Name_0: UTF-8 null-terminated]
+    [Name_1: UTF-8 null-terminated]
+    ...
+
+末尾には offset ペア（TagsOffset, AttribsOffset）があり，そこから辞書開始位置を得る．
+V1 は offset ペア 1 個のみ．
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+from .exceptions import FileDBParseError, UnsupportedFileDBVersion
+from .version import FileDBVersion
+
+
+@dataclass(frozen=True)
+class TagDictionary:
+    """ID → 名前 の辞書．Tag 用と Attrib 用で別インスタンスを作る．"""
+
+    entries: dict[int, str]
+
+    def __contains__(self, key: int) -> bool:
+        return key in self.entries
+
+    def __getitem__(self, key: int) -> str:
+        return self.entries[key]
+
+    def get(self, key: int, default: str | None = None) -> str | None:
+        return self.entries.get(key, default)
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+
+@dataclass(frozen=True)
+class TagSection:
+    """FileDB ドキュメント 1 本分の tag / attrib 辞書ペア．"""
+
+    tags: TagDictionary
+    attribs: TagDictionary
+
+
+def _parse_dictionary(data: bytes | memoryview, base: int) -> TagDictionary:
+    """``base`` 位置から 1 辞書分を decode する．"""
+    n = len(data)
+    if base < 0 or base + 4 > n:
+        raise FileDBParseError(f"dictionary offset out of range: base={base}")
+    count = struct.unpack_from("<i", data, base)[0]
+    if count < 0:
+        raise FileDBParseError(f"negative dictionary count: {count}")
+
+    ids_start = base + 4
+    ids_end = ids_start + 2 * count
+    if ids_end > n:
+        raise FileDBParseError("dictionary IDs extend past EOF")
+
+    ids: list[int] = [struct.unpack_from("<H", data, ids_start + 2 * i)[0] for i in range(count)]
+
+    pos = ids_end
+    entries: dict[int, str] = {}
+    for tid in ids:
+        try:
+            end = data.index(b"\x00", pos)
+        except ValueError as e:
+            raise FileDBParseError(f"dictionary name at pos={pos} is not null-terminated") from e
+        entries[tid] = bytes(data[pos:end]).decode("utf-8", errors="replace")
+        pos = end + 1
+    return TagDictionary(entries=entries)
+
+
+def parse_tag_section(data: bytes | memoryview, version: FileDBVersion) -> TagSection:
+    """末尾の offset ペアから tag / attrib 辞書を decode する．
+
+    V1 は attrib 辞書を持たない形式のためサポート外．
+    """
+    if version is FileDBVersion.V1:
+        raise UnsupportedFileDBVersion("FileDB V1 tag section layout is not supported in v0.2")
+
+    n = len(data)
+    offset_to_offsets = version.offset_to_offsets  # V2/V3 = 16
+    if n < offset_to_offsets:
+        raise FileDBParseError(
+            f"buffer too small for tag section (len={n}, need >= {offset_to_offsets})"
+        )
+    # offset block は末尾 magic の直前，計 2 * int32 = 8B．
+    ofs_start = n - offset_to_offsets
+    tags_offset = struct.unpack_from("<i", data, ofs_start)[0]
+    attribs_offset = struct.unpack_from("<i", data, ofs_start + 4)[0]
+
+    tags = _parse_dictionary(data, tags_offset)
+    attribs = _parse_dictionary(data, attribs_offset)
+    return TagSection(tags=tags, attribs=attribs)

--- a/src/anno_save_analyzer/parser/filedb/dom.py
+++ b/src/anno_save_analyzer/parser/filedb/dom.py
@@ -1,0 +1,153 @@
+"""DOM ストリーム走査．
+
+FileDB の DOM セクションは ``[bytesize: int32][id: int32]`` の繰り返し．
+id を signed int32 として解釈した上で以下の state を判定する:
+
+- ``id >= 32768`` → Attrib．直後に ``bytesize`` バイト分の content が続く
+  （V2/V3 は 8 バイト境界にパディングされる）．
+- ``0 < id < 32768`` → Tag（子要素を持つ入れ子の開始）．
+- ``id <= 0``        → Terminator（直近の Tag を閉じる）．
+
+本モジュールは **streaming iterator** として設計し，巨大な 165MB 級 DOM を
+O(chunk) メモリで消費できるようにする．
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import Enum
+
+from .dictionary import TagSection
+from .exceptions import FileDBParseError
+from .version import FileDBVersion
+
+_MAX_ID = 0x8000  # 32768
+
+
+class EventKind(Enum):
+    """DOM イベントの種別．"""
+
+    TAG = "tag"
+    ATTRIB = "attrib"
+    TERMINATOR = "terminator"
+
+
+@dataclass(frozen=True)
+class DomEvent:
+    """DOM ストリーム中の 1 イベント．
+
+    ``kind`` に応じて以下のフィールドを使い分ける:
+
+    - TAG: ``id_`` （open）．``name`` は ``tag_section`` 指定時に解決される．
+    - ATTRIB: ``id_`` / ``content`` （生バイト）．
+    - TERMINATOR: 閉じイベント．``id_=0`` / ``content=b""``．
+    """
+
+    kind: EventKind
+    id_: int
+    name: str | None = None
+    content: bytes = b""
+
+    @property
+    def is_tag(self) -> bool:
+        return self.kind is EventKind.TAG
+
+    @property
+    def is_attrib(self) -> bool:
+        return self.kind is EventKind.ATTRIB
+
+    @property
+    def is_terminator(self) -> bool:
+        return self.kind is EventKind.TERMINATOR
+
+
+# 後方互換的に `Tag` / `Attrib` / `Terminator` という簡易ファクトリも公開する．
+def Tag(id_: int, name: str | None = None) -> DomEvent:
+    return DomEvent(kind=EventKind.TAG, id_=id_, name=name)
+
+
+def Attrib(id_: int, content: bytes, name: str | None = None) -> DomEvent:
+    return DomEvent(kind=EventKind.ATTRIB, id_=id_, content=content, name=name)
+
+
+def Terminator() -> DomEvent:
+    return DomEvent(kind=EventKind.TERMINATOR, id_=0)
+
+
+def _block_space(bytesize: int, block_size: int) -> int:
+    """Attrib content を block アラインしたときのディスク上サイズ．"""
+    if block_size <= 0:
+        return bytesize
+    if bytesize <= 0:
+        return 0
+    return ((bytesize + block_size - 1) // block_size) * block_size
+
+
+def iter_dom(
+    data: bytes | memoryview,
+    version: FileDBVersion,
+    *,
+    tag_section: TagSection | None = None,
+    dom_end: int | None = None,
+) -> Iterator[DomEvent]:
+    """DOM セクションを streaming で走査し ``DomEvent`` を yield する．
+
+    ``dom_end`` を指定しないときは ``TagsOffset`` まで（= DOM の終端）を
+    自動計算する．引数 ``data`` は全体バッファを想定．
+    """
+    n = len(data)
+    if n < version.offset_to_offsets:
+        raise FileDBParseError("buffer too small to hold DOM and tag section")
+
+    if dom_end is None:
+        # TagsOffset 位置を DOM の終端として用いる．
+        ofs_start = n - version.offset_to_offsets
+        dom_end = struct.unpack_from("<i", data, ofs_start)[0]
+        if not (0 <= dom_end <= n):
+            raise FileDBParseError(f"TagsOffset out of bounds: {dom_end}")
+
+    block_size = version.block_size
+    pos = 0
+    depth = 0
+
+    while pos < dom_end:
+        if pos + 8 > dom_end:
+            raise FileDBParseError(f"unexpected EOF in DOM header at pos={pos} (dom_end={dom_end})")
+        bytesize, raw_id = struct.unpack_from("<iI", data, pos)
+        pos += 8
+        # signed int32 として解釈
+        id_signed = struct.unpack("<i", struct.pack("<I", raw_id))[0]
+        id16 = raw_id & 0xFFFF
+
+        if id_signed <= 0:
+            # Terminator: DOM の最後は depth=-1 に落ちる追加 terminator で終わる．
+            yield Terminator()
+            depth -= 1
+            if depth < -1:
+                raise FileDBParseError("more Terminators than opened Tags")
+            continue
+
+        if id16 >= _MAX_ID:
+            # Attrib
+            content_disk = _block_space(bytesize, block_size)
+            if pos + content_disk > dom_end:
+                raise FileDBParseError(
+                    f"Attrib content extends past DOM end: pos={pos} "
+                    f"need={content_disk} dom_end={dom_end}"
+                )
+            content = bytes(data[pos : pos + bytesize])
+            pos += content_disk
+            name = None
+            if tag_section is not None:
+                name = tag_section.attribs.get(id16)
+            yield Attrib(id_=id16, content=content, name=name)
+            continue
+
+        # 残り: Tag（0 < id16 < 32768）
+        name = None
+        if tag_section is not None:
+            name = tag_section.tags.get(id16)
+        yield Tag(id_=id16, name=name)
+        depth += 1

--- a/src/anno_save_analyzer/parser/filedb/exceptions.py
+++ b/src/anno_save_analyzer/parser/filedb/exceptions.py
@@ -1,0 +1,11 @@
+"""FileDB parser 用例外クラス．"""
+
+from __future__ import annotations
+
+
+class FileDBParseError(Exception):
+    """FileDB バイナリの構造破損や仕様違反を検出したとき送出する汎用例外．"""
+
+
+class UnsupportedFileDBVersion(FileDBParseError):
+    """magic から判定したバージョンが実装対象外のとき送出する例外．"""

--- a/src/anno_save_analyzer/parser/filedb/session.py
+++ b/src/anno_save_analyzer/parser/filedb/session.py
@@ -1,0 +1,66 @@
+"""SessionData / BinaryData の再帰 FileDB 抽出ヘルパ．
+
+Anno 1800 セーブ内部の FileDB V3 DOM には ``<SessionData>`` タグが複数含まれ，
+各 SessionData 配下に ``<BinaryData>`` Attrib として **再び完全な FileDB V3 文書**が
+封入されている（2026-04-19 の調査で実測確認）．
+
+本モジュールは外側 FileDB バイト列を受け取り，5 セッション分の内部 FileDB バイト列を
+抜き出して ``list[bytes]`` として返す．呼び出し側は各要素を再度 :mod:`parser.filedb`
+で parse することで，島 / 建物 / 人口などの階層データを取得できる．
+"""
+
+from __future__ import annotations
+
+from .dictionary import TagSection, parse_tag_section
+from .dom import EventKind, iter_dom
+from .exceptions import FileDBParseError
+from .version import FileDBVersion, detect_version
+
+_SESSION_TAG_NAME = "SessionData"
+_BINARY_ATTRIB_NAME = "BinaryData"
+
+
+def _resolve_session_ids(section: TagSection) -> tuple[int, int]:
+    session_tag_id: int | None = next(
+        (tid for tid, name in section.tags.entries.items() if name == _SESSION_TAG_NAME),
+        None,
+    )
+    binary_attrib_id: int | None = next(
+        (aid for aid, name in section.attribs.entries.items() if name == _BINARY_ATTRIB_NAME),
+        None,
+    )
+    if session_tag_id is None or binary_attrib_id is None:
+        raise FileDBParseError(
+            "outer FileDB does not expose SessionData / BinaryData names in its dictionary"
+        )
+    return session_tag_id, binary_attrib_id
+
+
+def extract_sessions(
+    outer: bytes | memoryview,
+    version: FileDBVersion | None = None,
+    tag_section: TagSection | None = None,
+) -> list[bytes]:
+    """外側 FileDB の DOM を走査し ``<SessionData><BinaryData>`` の content を全件返す．
+
+    ``version`` / ``tag_section`` を呼び出し側で既に取得済なら引数で渡せる（再計算を避ける）．
+    """
+    if version is None:
+        version = detect_version(outer)
+    if tag_section is None:
+        tag_section = parse_tag_section(outer, version)
+
+    session_tag_id, binary_attrib_id = _resolve_session_ids(tag_section)
+
+    sessions: list[bytes] = []
+    depth_in_session = 0
+    for ev in iter_dom(outer, version, tag_section=tag_section):
+        if ev.kind is EventKind.TAG and ev.id_ == session_tag_id:
+            depth_in_session += 1
+            continue
+        if ev.kind is EventKind.TERMINATOR and depth_in_session > 0:
+            depth_in_session -= 1
+            continue
+        if ev.kind is EventKind.ATTRIB and ev.id_ == binary_attrib_id and depth_in_session > 0:
+            sessions.append(ev.content)
+    return sessions

--- a/src/anno_save_analyzer/parser/filedb/version.py
+++ b/src/anno_save_analyzer/parser/filedb/version.py
@@ -1,0 +1,80 @@
+"""FileDB V1 / V2 / V3 判定．
+
+末尾 8 バイトに置かれるマジックバイトでバージョンを決める．
+V1 は無 magic で，``V2/V3 のいずれでもない`` ことから推定する．
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from .exceptions import FileDBParseError
+
+# 末尾マジック（Versioning.GetMagicBytes と一致）
+_MAGIC_V2 = bytes.fromhex("08000000FEFFFFFF")
+_MAGIC_V3 = bytes.fromhex("08000000FDFFFFFF")
+
+# 辞書末尾から遡って offset ペアを読む距離 (Length - OffsetToOffsets)
+OFFSET_TO_OFFSETS = {
+    # V1 は 4 (int32 単一)，V2/V3 は 16 (int32×2 + magic 8B)
+    "V1": 4,
+    "V2": 16,
+    "V3": 16,
+}
+
+# Attrib content の blockspace (padded size) 計算用
+BLOCK_SIZE = {
+    "V1": 0,  # V1 は padding 無し
+    "V2": 8,
+    "V3": 8,
+}
+
+
+class FileDBVersion(Enum):
+    """FileDB ドキュメントのバージョン．"""
+
+    V1 = "V1"
+    V2 = "V2"
+    V3 = "V3"
+
+    @property
+    def offset_to_offsets(self) -> int:
+        """末尾から辞書オフセットブロックまでの距離．"""
+        return OFFSET_TO_OFFSETS[self.value]
+
+    @property
+    def block_size(self) -> int:
+        """Attrib content の padding 単位（V2/V3=8, V1=0）．"""
+        return BLOCK_SIZE[self.value]
+
+    @property
+    def uses_attrib_blocks(self) -> bool:
+        """Attrib content が block アラインされるか．V1 は False．"""
+        return self.block_size > 0
+
+
+def detect_version(data: bytes | memoryview) -> FileDBVersion:
+    """FileDB バイト列の末尾マジックからバージョンを判定する．
+
+    V2 / V3 にマッチしなければ V1 として扱う（上流実装と同じ挙動）．
+    ただし最低限 ``OffsetToOffsets`` バイトは必要．
+    """
+    if len(data) < 8:
+        raise FileDBParseError(
+            f"file too small to detect FileDB version (got {len(data)}B, need >= 8B)"
+        )
+    tail = bytes(data[-8:])
+    if tail == _MAGIC_V3:
+        return FileDBVersion.V3
+    if tail == _MAGIC_V2:
+        return FileDBVersion.V2
+    return FileDBVersion.V1
+
+
+def magic_bytes(version: FileDBVersion) -> bytes | None:
+    """指定 version のマジックバイト列（V1 は ``None``）．"""
+    if version is FileDBVersion.V2:
+        return _MAGIC_V2
+    if version is FileDBVersion.V3:
+        return _MAGIC_V3
+    return None

--- a/src/anno_save_analyzer/parser/filedb/xml.py
+++ b/src/anno_save_analyzer/parser/filedb/xml.py
@@ -1,0 +1,88 @@
+"""DOM イベントを lxml ``Element`` ツリーに変換する．
+
+Attrib の content は bytes のまま hex エンコードして保持する（interpreter 層で
+型変換する想定）．Tag / Attrib の名前は ``TagSection`` で解決される．
+名前未定義の ID は ``Tag_{id}`` / ``Attrib_{id}`` のフォールバックを使う．
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lxml import etree
+
+from .dictionary import TagSection, parse_tag_section
+from .dom import DomEvent, EventKind, iter_dom
+from .exceptions import FileDBParseError
+from .version import FileDBVersion, detect_version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+_ROOT_TAG = "FileDBDocument"
+
+
+def _safe_name(raw: str | None, prefix: str, id_: int) -> str:
+    if raw is None or raw == "":
+        return f"{prefix}_{id_}"
+    # XML 名として不正な文字を簡易にサニタイズ．本実装は spec 層なので
+    # 先頭英字保証と空白 / 記号の排除のみ．
+    cleaned = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in raw)
+    if not cleaned or not (cleaned[0].isalpha() or cleaned[0] == "_"):
+        cleaned = f"_{cleaned}"
+    return cleaned
+
+
+def build_xml_from_events(
+    events: Iterable[DomEvent],
+    tag_section: TagSection | None = None,
+) -> etree._Element:
+    """DOM イベント列から lxml ``Element`` ツリーを組み上げる．
+
+    ルート要素 ``<FileDBDocument>`` の直下に DOM の各ルートタグが並ぶ．
+    Attrib は子要素 ``<attrib name="..." id="..." hex="..."/>`` として表現する．
+    """
+    root = etree.Element(_ROOT_TAG)
+    stack: list[etree._Element] = [root]
+
+    for ev in events:
+        if ev.kind is EventKind.TAG:
+            parent = stack[-1]
+            name = _safe_name(ev.name, "Tag", ev.id_)
+            node = etree.SubElement(parent, name)
+            node.set("id", str(ev.id_))
+            stack.append(node)
+            continue
+        if ev.kind is EventKind.ATTRIB:
+            parent = stack[-1]
+            name = _safe_name(ev.name, "Attrib", ev.id_)
+            node = etree.SubElement(parent, name)
+            node.set("id", str(ev.id_))
+            node.set("hex", ev.content.hex())
+            continue
+        # Terminator
+        if len(stack) <= 1:
+            # ルートレベルでの余分な terminator は DOM セクション終了マーカ．
+            continue
+        stack.pop()
+
+    return root
+
+
+def build_xml(
+    data: bytes | memoryview,
+    version: FileDBVersion | None = None,
+) -> etree._Element:
+    """FileDB バイト列から一発で lxml ``Element`` を作るワンショット API．
+
+    辞書解決つき．メモリ上にツリー全体を構築するため巨大ファイルには向かない
+    （その場合は ``iter_dom`` を直接使う）．
+    """
+    if version is None:
+        version = detect_version(data)
+    if version is FileDBVersion.V1:
+        raise FileDBParseError("FileDB V1 XML building is not supported in v0.2")
+    section = parse_tag_section(data, version)
+    events = iter_dom(data, version, tag_section=section)
+    return build_xml_from_events(events, section)

--- a/tests/parser/filedb/conftest.py
+++ b/tests/parser/filedb/conftest.py
@@ -1,0 +1,105 @@
+"""FileDB テスト用のフィクスチャビルダ．
+
+V2 / V3 の最小 FileDB バイト列を手続き的に組み立てるユーティリティ．
+境界系の破壊的パラメータも受け付け，壊れた入力で error path を踏ませる．
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+from typing import Literal
+
+from anno_save_analyzer.parser.filedb.version import (
+    _MAGIC_V2,
+    _MAGIC_V3,
+    FileDBVersion,
+)
+
+AttribEvent = tuple[Literal["A"], int, bytes]  # (kind, id, content)
+TagEvent = tuple[Literal["T"], int]  # (kind, id)
+TermEvent = tuple[Literal["X"]]  # terminator
+Event = AttribEvent | TagEvent | TermEvent
+
+
+def _block_pad(content: bytes, block_size: int) -> bytes:
+    """Attrib content を block 境界まで 0 パディング．"""
+    if block_size <= 0 or len(content) == 0:
+        return content
+    padding = (-len(content)) % block_size
+    return content + b"\x00" * padding
+
+
+def encode_dom(events: list[Event], block_size: int) -> bytes:
+    """イベント列を FileDB DOM バイト列にエンコード．"""
+    out = bytearray()
+    for ev in events:
+        if ev[0] == "A":
+            _, id_, content = ev
+            out += struct.pack("<iI", len(content), id_)
+            out += _block_pad(content, block_size)
+        elif ev[0] == "T":
+            _, id_ = ev
+            out += struct.pack("<iI", 0, id_)
+        else:  # "X" terminator
+            out += struct.pack("<iI", 0, 0)
+    return bytes(out)
+
+
+def encode_dictionary(mapping: dict[int, str]) -> bytes:
+    """V2/V3 辞書 ``[Count:i32][IDs:u16×N][Names:UTF-8 0x00]`` をエンコード．"""
+    ids = list(mapping.keys())
+    count = len(ids)
+    out = bytearray()
+    out += struct.pack("<i", count)
+    for tid in ids:
+        out += struct.pack("<H", tid)
+    for tid in ids:
+        out += mapping[tid].encode("utf-8") + b"\x00"
+    return bytes(out)
+
+
+@dataclass
+class FileDBFixture:
+    """FileDB V2/V3 1 本分を構築するスペック．"""
+
+    version: FileDBVersion = FileDBVersion.V3
+    tags: dict[int, str] = field(default_factory=dict)
+    attribs: dict[int, str] = field(default_factory=dict)
+    events: list[Event] = field(default_factory=list)
+
+    # 境界試験用の override フック
+    override_tag_offset: int | None = None
+    override_attrib_offset: int | None = None
+    override_magic: bytes | None = None
+
+    def build(self) -> bytes:
+        block_size = self.version.block_size
+        dom = encode_dom(self.events, block_size)
+        tag_dict_bytes = encode_dictionary(self.tags)
+        attrib_dict_bytes = encode_dictionary(self.attribs)
+
+        tags_offset = len(dom)
+        attribs_offset = tags_offset + len(tag_dict_bytes)
+        if self.override_tag_offset is not None:
+            tags_offset = self.override_tag_offset
+        if self.override_attrib_offset is not None:
+            attribs_offset = self.override_attrib_offset
+
+        out = bytearray()
+        out += dom
+        out += tag_dict_bytes
+        out += attrib_dict_bytes
+        out += struct.pack("<ii", tags_offset, attribs_offset)
+        magic = self.override_magic
+        if magic is None:
+            magic = _MAGIC_V3 if self.version is FileDBVersion.V3 else _MAGIC_V2
+        out += magic
+        return bytes(out)
+
+
+def minimal_v3(tags: dict[int, str], attribs: dict[int, str], events: list[Event]) -> bytes:
+    """V3 最小 FileDB を合成．"""
+    return FileDBFixture(
+        version=FileDBVersion.V3, tags=tags, attribs=attribs, events=events
+    ).build()

--- a/tests/parser/filedb/test_dictionary.py
+++ b/tests/parser/filedb/test_dictionary.py
@@ -1,0 +1,96 @@
+"""dictionary.py のテスト．"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from anno_save_analyzer.parser.filedb import (
+    FileDBParseError,
+    FileDBVersion,
+    UnsupportedFileDBVersion,
+    parse_tag_section,
+)
+from anno_save_analyzer.parser.filedb.dictionary import (
+    TagDictionary,
+    _parse_dictionary,
+)
+
+from .conftest import FileDBFixture, encode_dictionary, minimal_v3
+
+
+class TestTagDictionary:
+    def test_membership_and_lookup(self) -> None:
+        d = TagDictionary(entries={1: "a", 2: "b"})
+        assert 1 in d
+        assert 99 not in d
+        assert d[1] == "a"
+        assert d.get(1) == "a"
+        assert d.get(99) is None
+        assert d.get(99, "fallback") == "fallback"
+        assert len(d) == 2
+
+
+class TestParseDictionaryHappy:
+    def test_round_trip_minimal(self) -> None:
+        data = encode_dictionary({1: "alpha", 2: "beta", 3: "gamma"})
+        d = _parse_dictionary(data, 0)
+        assert d.entries == {1: "alpha", 2: "beta", 3: "gamma"}
+
+    def test_parse_tag_section_v3(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Root"},
+            attribs={0x8001: "x"},
+            events=[("T", 1), ("A", 0x8001, b"\x01\x02\x03\x04"), ("X",)],
+        )
+        section = parse_tag_section(blob, FileDBVersion.V3)
+        assert section.tags.entries == {1: "Root"}
+        assert section.attribs.entries == {0x8001: "x"}
+
+
+class TestParseDictionaryErrors:
+    def test_negative_offset_raises(self) -> None:
+        with pytest.raises(FileDBParseError, match="out of range"):
+            _parse_dictionary(b"\x00" * 32, -1)
+
+    def test_offset_past_end_raises(self) -> None:
+        with pytest.raises(FileDBParseError, match="out of range"):
+            _parse_dictionary(b"\x00" * 4, 100)
+
+    def test_negative_count_raises(self) -> None:
+        data = struct.pack("<i", -1)
+        with pytest.raises(FileDBParseError, match="negative dictionary count"):
+            _parse_dictionary(data, 0)
+
+    def test_ids_past_eof_raises(self) -> None:
+        # Count=5 だが IDs バイトが足りない
+        data = struct.pack("<i", 5) + b"\x00\x01"
+        with pytest.raises(FileDBParseError, match="extend past EOF"):
+            _parse_dictionary(data, 0)
+
+    def test_name_not_null_terminated(self) -> None:
+        # Count=1, ID=1, 名前が null で終わらない
+        data = struct.pack("<i", 1) + struct.pack("<H", 1) + b"abc"
+        with pytest.raises(FileDBParseError, match="not null-terminated"):
+            _parse_dictionary(data, 0)
+
+
+class TestParseTagSectionErrors:
+    def test_v1_unsupported(self) -> None:
+        with pytest.raises(UnsupportedFileDBVersion):
+            parse_tag_section(b"\x00" * 32, FileDBVersion.V1)
+
+    def test_buffer_too_small(self) -> None:
+        with pytest.raises(FileDBParseError, match="too small"):
+            parse_tag_section(b"\x00" * 4, FileDBVersion.V3)
+
+    def test_override_bad_offsets_raises(self) -> None:
+        blob = FileDBFixture(
+            tags={1: "Root"},
+            attribs={0x8001: "x"},
+            events=[("T", 1), ("X",)],
+            override_tag_offset=999_999,
+        ).build()
+        with pytest.raises(FileDBParseError):
+            parse_tag_section(blob, FileDBVersion.V3)

--- a/tests/parser/filedb/test_dom.py
+++ b/tests/parser/filedb/test_dom.py
@@ -1,0 +1,193 @@
+"""dom.py のテスト．"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from anno_save_analyzer.parser.filedb import (
+    Attrib,
+    DomEvent,
+    EventKind,
+    FileDBParseError,
+    FileDBVersion,
+    Tag,
+    Terminator,
+    iter_dom,
+    parse_tag_section,
+)
+from anno_save_analyzer.parser.filedb.dom import _block_space
+
+from .conftest import FileDBFixture, minimal_v3
+
+
+class TestBlockSpace:
+    @pytest.mark.parametrize(
+        "bytesize, block, expected",
+        [
+            (0, 8, 0),
+            (1, 8, 8),
+            (8, 8, 8),
+            (9, 8, 16),
+            (16, 8, 16),
+            (5, 0, 5),  # V1 は padding 無し
+            (-3, 8, 0),  # 負数はゼロに潰す（防御）
+        ],
+    )
+    def test_block_space(self, bytesize: int, block: int, expected: int) -> None:
+        assert _block_space(bytesize, block) == expected
+
+
+class TestIterDomHappyPaths:
+    def test_minimal_v3_roundtrip(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Root", 2: "Child"},
+            attribs={0x8001: "x", 0x8002: "y"},
+            events=[
+                ("T", 1),
+                ("A", 0x8001, b"\xaa\xbb"),
+                ("T", 2),
+                ("A", 0x8002, b"\x01\x02\x03\x04"),
+                ("X",),  # close Child
+                ("X",),  # close Root
+                ("X",),  # DOM terminator
+            ],
+        )
+        section = parse_tag_section(blob, FileDBVersion.V3)
+        events = list(iter_dom(blob, FileDBVersion.V3, tag_section=section))
+
+        kinds = [(e.kind, e.id_, e.name) for e in events]
+        assert kinds == [
+            (EventKind.TAG, 1, "Root"),
+            (EventKind.ATTRIB, 0x8001, "x"),
+            (EventKind.TAG, 2, "Child"),
+            (EventKind.ATTRIB, 0x8002, "y"),
+            (EventKind.TERMINATOR, 0, None),
+            (EventKind.TERMINATOR, 0, None),
+            (EventKind.TERMINATOR, 0, None),
+        ]
+        # Attrib の content
+        attrib_events = [e for e in events if e.kind is EventKind.ATTRIB]
+        assert attrib_events[0].content == b"\xaa\xbb"
+        assert attrib_events[1].content == b"\x01\x02\x03\x04"
+
+    def test_iter_dom_without_tag_section_leaves_names_none(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Root"},
+            attribs={0x8001: "x"},
+            events=[("T", 1), ("A", 0x8001, b"\x00"), ("X",)],
+        )
+        events = list(iter_dom(blob, FileDBVersion.V3))
+        assert all(ev.name is None for ev in events)
+
+    def test_iter_dom_with_explicit_dom_end(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Root"},
+            attribs={},
+            events=[("T", 1), ("X",)],
+        )
+        # dom_end=0 は空 DOM — 何も yield しない．
+        events = list(iter_dom(blob, FileDBVersion.V3, dom_end=0))
+        assert events == []
+
+    def test_attrib_content_padding_applied(self) -> None:
+        """V3 で 3 バイトの content は disk 上 8 バイト（パディング済）になる．"""
+        content = b"\x11\x22\x33"
+        blob = minimal_v3(
+            tags={1: "R"},
+            attribs={0x8001: "a"},
+            events=[("T", 1), ("A", 0x8001, content), ("X",)],
+        )
+        events = list(iter_dom(blob, FileDBVersion.V3))
+        attrib_ev = next(e for e in events if e.kind is EventKind.ATTRIB)
+        # 正味 content は 3 バイトだが，次の terminator が正しく読めることで padding 境界正確性を確認
+        assert attrib_ev.content == content
+        terminators = [e for e in events if e.kind is EventKind.TERMINATOR]
+        assert len(terminators) == 1
+
+
+class TestDomEventProperties:
+    def test_tag_factory_and_flags(self) -> None:
+        t = Tag(5, name="Foo")
+        assert t.is_tag and not t.is_attrib and not t.is_terminator
+        assert t.id_ == 5 and t.name == "Foo"
+
+    def test_attrib_factory_and_flags(self) -> None:
+        a = Attrib(0x8001, b"\x00\x01")
+        assert a.is_attrib and not a.is_tag and not a.is_terminator
+        assert a.content == b"\x00\x01"
+
+    def test_terminator_factory(self) -> None:
+        x = Terminator()
+        assert x.is_terminator and not x.is_tag and not x.is_attrib
+        assert x.id_ == 0
+
+    def test_direct_construction_via_dataclass(self) -> None:
+        ev = DomEvent(kind=EventKind.TAG, id_=7)
+        assert ev.id_ == 7
+        assert ev.name is None
+        assert ev.content == b""
+
+
+class TestIterDomErrors:
+    def test_buffer_too_small(self) -> None:
+        with pytest.raises(FileDBParseError, match="too small"):
+            list(iter_dom(b"\x00" * 4, FileDBVersion.V3))
+
+    def test_tags_offset_out_of_bounds(self) -> None:
+        # 小さいバッファに TagsOffset=負数を埋めて OOB 発火
+        blob = bytearray(b"\x00" * 32)
+        # offset ペア + magic の位置 (末尾 16B) に負の TagsOffset を書く
+        struct.pack_into("<ii", blob, len(blob) - 16, -1, 0)
+        with pytest.raises(FileDBParseError, match="TagsOffset"):
+            list(iter_dom(bytes(blob), FileDBVersion.V3))
+
+    def test_eof_in_dom_header(self) -> None:
+        """DOM 途中で 4 バイトだけ残して header の 8 バイトが読めないケース．"""
+        blob = FileDBFixture(
+            tags={1: "R"},
+            attribs={},
+            # わざと 1 件だけ event を詰め，そのあと 4 バイトのゴミを挟んでから dict へ
+            events=[("T", 1), ("X",)],
+        ).build()
+        # TagsOffset が DOM + 4B のゴミを含むように手で調整する: DOM 長 + 4
+        import struct as _s
+
+        ts_offset_pos = len(blob) - 16
+        original_ts_offset = _s.unpack_from("<i", blob, ts_offset_pos)[0]
+        new_blob = bytearray(blob)
+        # DOM と dict の間に 4 バイトゴミを挿入
+        new_blob[original_ts_offset:original_ts_offset] = b"\xff\xff\xff\xff"
+        # offset をずらす
+        _s.pack_into(
+            "<ii",
+            new_blob,
+            ts_offset_pos + 4,
+            original_ts_offset + 4,
+            _s.unpack_from("<i", blob, ts_offset_pos + 4)[0] + 4,
+        )
+        with pytest.raises(FileDBParseError, match="unexpected EOF"):
+            list(iter_dom(bytes(new_blob), FileDBVersion.V3))
+
+    def test_attrib_content_overruns_dom_end(self) -> None:
+        """Attrib bytesize が DOM 残量より大きい場合のエラー．"""
+        # TagsOffset を DOM 開始直後に強制設定．attrib header の 8B は読めるが content が超過
+        blob = FileDBFixture(
+            tags={1: "R"},
+            attribs={0x8001: "x"},
+            events=[("A", 0x8001, b"\x00" * 64)],
+            override_tag_offset=8,  # DOM=8B (header のみ) とする．content 64B は超過
+        ).build()
+        with pytest.raises(FileDBParseError, match="past DOM end"):
+            list(iter_dom(blob, FileDBVersion.V3))
+
+    def test_too_many_terminators(self) -> None:
+        """Tag を開かずに Terminator 連発 → depth < -1 で例外．"""
+        blob = minimal_v3(
+            tags={},
+            attribs={},
+            events=[("X",), ("X",), ("X",)],
+        )
+        with pytest.raises(FileDBParseError, match="more Terminators"):
+            list(iter_dom(blob, FileDBVersion.V3))

--- a/tests/parser/filedb/test_session.py
+++ b/tests/parser/filedb/test_session.py
@@ -1,0 +1,76 @@
+"""session.py のテスト．
+
+SessionData/BinaryData が再帰 FileDB であることを実地で確認した上で，
+外側 DOM からの抽出ロジックを合成フィクスチャで検証する．
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from anno_save_analyzer.parser.filedb import (
+    FileDBParseError,
+    FileDBVersion,
+    detect_version,
+    extract_sessions,
+    parse_tag_section,
+)
+
+from .conftest import minimal_v3
+
+
+def _wrap_inner_filedb_as_session_blob(inner: bytes) -> bytes:
+    """inner を BinaryData attrib として <SessionData> タグに包んだ外側 FileDB を合成．"""
+    return minimal_v3(
+        tags={1: "SessionData", 2: "Ignored"},
+        attribs={0x8001: "BinaryData", 0x8002: "other"},
+        events=[
+            # 無関係な BinaryData（session 外）
+            ("A", 0x8001, b"\xca\xfe"),
+            # 1 つ目の SessionData 配下
+            ("T", 1),
+            ("A", 0x8001, inner),
+            ("X",),
+            # 2 つ目の SessionData（空 BinaryData で複数件を検証）
+            ("T", 1),
+            ("A", 0x8001, b""),
+            ("X",),
+            # 別の tag 内の BinaryData（抽出されないこと）
+            ("T", 2),
+            ("A", 0x8001, b"\x00\x01\x02"),
+            ("X",),
+        ],
+    )
+
+
+class TestExtractSessionsHappy:
+    def test_extracts_only_session_scoped_binary_attribs(self) -> None:
+        inner_data = b"\x01\x02\x03\x04" * 32
+        outer = _wrap_inner_filedb_as_session_blob(inner_data)
+        sessions = extract_sessions(outer)
+        assert sessions == [inner_data, b""]
+
+    def test_accepts_precomputed_version_and_section(self) -> None:
+        inner_data = b"\xaa" * 16
+        outer = _wrap_inner_filedb_as_session_blob(inner_data)
+        version = detect_version(outer)
+        section = parse_tag_section(outer, version)
+        sessions = extract_sessions(outer, version=version, tag_section=section)
+        assert sessions == [inner_data, b""]
+
+
+class TestExtractSessionsErrors:
+    def test_raises_when_dictionary_lacks_names(self) -> None:
+        """SessionData / BinaryData 名が辞書に無い外側 FileDB は扱えない．"""
+        outer = minimal_v3(
+            tags={1: "Other"},
+            attribs={0x8001: "NotBinary"},
+            events=[("T", 1), ("A", 0x8001, b"\x00"), ("X",)],
+        )
+        with pytest.raises(FileDBParseError, match="SessionData"):
+            extract_sessions(outer)
+
+    def test_unsupported_outer_version_raises(self) -> None:
+        """外側が V1 だと tag section が parse 不可のため FileDBParseError が連鎖する．"""
+        with pytest.raises(FileDBParseError):
+            extract_sessions(b"\x00" * 32, version=FileDBVersion.V1)

--- a/tests/parser/filedb/test_version.py
+++ b/tests/parser/filedb/test_version.py
@@ -1,0 +1,69 @@
+"""version.py のテスト．"""
+
+from __future__ import annotations
+
+import pytest
+
+from anno_save_analyzer.parser.filedb import FileDBVersion, UnsupportedFileDBVersion
+from anno_save_analyzer.parser.filedb.exceptions import FileDBParseError
+from anno_save_analyzer.parser.filedb.version import (
+    _MAGIC_V2,
+    _MAGIC_V3,
+    detect_version,
+    magic_bytes,
+)
+
+
+class TestDetectVersion:
+    def test_v2_magic_detected(self) -> None:
+        data = b"\x00" * 24 + _MAGIC_V2
+        assert detect_version(data) is FileDBVersion.V2
+
+    def test_v3_magic_detected(self) -> None:
+        data = b"\x00" * 24 + _MAGIC_V3
+        assert detect_version(data) is FileDBVersion.V3
+
+    def test_no_match_falls_back_to_v1(self) -> None:
+        """マッチしない末尾は V1 扱い．上流 ``VersionDetector`` と同じ挙動．"""
+        data = b"\xde\xad\xbe\xef" * 4
+        assert detect_version(data) is FileDBVersion.V1
+
+    def test_memoryview_input(self) -> None:
+        data = memoryview(b"\x00" * 16 + _MAGIC_V3)
+        assert detect_version(data) is FileDBVersion.V3
+
+    def test_too_short_raises(self) -> None:
+        with pytest.raises(FileDBParseError, match="too small"):
+            detect_version(b"\x00\x01\x02")
+
+
+class TestMagicBytesAndVersion:
+    def test_magic_bytes_v2(self) -> None:
+        assert magic_bytes(FileDBVersion.V2) == _MAGIC_V2
+
+    def test_magic_bytes_v3(self) -> None:
+        assert magic_bytes(FileDBVersion.V3) == _MAGIC_V3
+
+    def test_magic_bytes_v1_is_none(self) -> None:
+        assert magic_bytes(FileDBVersion.V1) is None
+
+    def test_offset_to_offsets_v2_v3_is_16(self) -> None:
+        assert FileDBVersion.V2.offset_to_offsets == 16
+        assert FileDBVersion.V3.offset_to_offsets == 16
+
+    def test_offset_to_offsets_v1_is_4(self) -> None:
+        assert FileDBVersion.V1.offset_to_offsets == 4
+
+    def test_block_size(self) -> None:
+        assert FileDBVersion.V1.block_size == 0
+        assert FileDBVersion.V2.block_size == 8
+        assert FileDBVersion.V3.block_size == 8
+
+    def test_uses_attrib_blocks(self) -> None:
+        assert FileDBVersion.V3.uses_attrib_blocks
+        assert FileDBVersion.V2.uses_attrib_blocks
+        assert not FileDBVersion.V1.uses_attrib_blocks
+
+    def test_unsupported_version_type(self) -> None:
+        # UnsupportedFileDBVersion は FileDBParseError のサブクラス．
+        assert issubclass(UnsupportedFileDBVersion, FileDBParseError)

--- a/tests/parser/filedb/test_xml.py
+++ b/tests/parser/filedb/test_xml.py
@@ -1,0 +1,106 @@
+"""xml.py のテスト．"""
+
+from __future__ import annotations
+
+import pytest
+from lxml import etree
+
+from anno_save_analyzer.parser.filedb import FileDBParseError, FileDBVersion, build_xml
+from anno_save_analyzer.parser.filedb.dom import Attrib, Tag, Terminator
+from anno_save_analyzer.parser.filedb.xml import _safe_name, build_xml_from_events
+
+from .conftest import minimal_v3
+
+
+class TestBuildXmlEndToEnd:
+    def test_minimal_v3_tree_shape(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Root", 2: "Child"},
+            attribs={0x8001: "value"},
+            events=[
+                ("T", 1),
+                ("T", 2),
+                ("A", 0x8001, b"\xde\xad\xbe\xef"),
+                ("X",),
+                ("X",),
+                ("X",),
+            ],
+        )
+        root = build_xml(blob)
+        assert root.tag == "FileDBDocument"
+        # Root → Child → value
+        root_tag = root[0]
+        assert root_tag.tag == "Root"
+        assert root_tag.get("id") == "1"
+        child_tag = root_tag[0]
+        assert child_tag.tag == "Child"
+        value_attr = child_tag[0]
+        assert value_attr.tag == "value"
+        assert value_attr.get("hex") == "deadbeef"
+
+    def test_build_xml_explicit_version_parameter(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Only"},
+            attribs={},
+            events=[("T", 1), ("X",), ("X",)],
+        )
+        root = build_xml(blob, version=FileDBVersion.V3)
+        assert root[0].tag == "Only"
+
+    def test_build_xml_v1_unsupported(self) -> None:
+        with pytest.raises(FileDBParseError, match="V1"):
+            build_xml(b"\x00" * 32, version=FileDBVersion.V1)
+
+
+class TestBuildXmlFromEvents:
+    def test_root_level_terminator_is_noop(self) -> None:
+        root = build_xml_from_events([Terminator()])
+        assert root.tag == "FileDBDocument"
+        assert len(root) == 0
+
+    def test_unresolved_tag_name_falls_back(self) -> None:
+        """tag_section 無しで名前未解決なら ``Tag_{id}`` フォールバック．"""
+        root = build_xml_from_events([Tag(42), Terminator()])
+        assert root[0].tag == "Tag_42"
+        assert root[0].get("id") == "42"
+
+    def test_unresolved_attrib_name_falls_back(self) -> None:
+        root = build_xml_from_events([Tag(1, name="R"), Attrib(99, b"\x01"), Terminator()])
+        r = root[0]
+        assert r.tag == "R"
+        assert r[0].tag == "Attrib_99"
+        assert r[0].get("hex") == "01"
+
+
+class TestSafeName:
+    def test_none_falls_to_prefix(self) -> None:
+        assert _safe_name(None, "Tag", 7) == "Tag_7"
+
+    def test_empty_string_falls_to_prefix(self) -> None:
+        assert _safe_name("", "Attrib", 3) == "Attrib_3"
+
+    def test_special_chars_sanitized(self) -> None:
+        assert _safe_name("foo.bar-baz", "Tag", 1) == "foo_bar_baz"
+
+    def test_leading_digit_prefixed_with_underscore(self) -> None:
+        assert _safe_name("1abc", "Tag", 1) == "_1abc"
+
+    def test_all_special_chars_sanitized_to_underscores_keeps_leading_underscore(
+        self,
+    ) -> None:
+        # "/" は全て `_` に置換 → "_" が残る．XML 名として有効な先頭．
+        assert _safe_name("////", "Tag", 9) == "____"
+
+
+class TestXmlSerialization:
+    def test_tree_serializes_to_valid_xml(self) -> None:
+        blob = minimal_v3(
+            tags={1: "Sample"},
+            attribs={0x8001: "note"},
+            events=[("T", 1), ("A", 0x8001, b"\x00"), ("X",), ("X",)],
+        )
+        root = build_xml(blob)
+        serialized = etree.tostring(root, pretty_print=True).decode()
+        assert "<FileDBDocument>" in serialized
+        assert "<Sample" in serialized
+        assert 'hex="00"' in serialized


### PR DESCRIPTION
## Summary

v0.2 の step 1〜4（version 判定 / 辞書 decode / DOM streaming / lxml XML 変換）を実装．Pydantic model 層（step 5）は別 issue (#10) に分離．

### 実装した公開 API

| API | 役割 |
|---|---|
| ``FileDBVersion`` / ``detect_version(data)`` | 末尾 8B magic から V1/V2/V3 判定 |
| ``parse_tag_section(data, version) → TagSection`` | tag / attrib 辞書 decode |
| ``iter_dom(data, version, tag_section=...) → Iterator[DomEvent]`` | streaming DOM 走査 |
| ``build_xml(data) → lxml.etree._Element`` | ワンショット XML 変換 |
| ``FileDBParseError`` / ``UnsupportedFileDBVersion`` | 例外階層 |

### 内部構成

- ``src/anno_save_analyzer/parser/filedb/`` 配下に version / dictionary / dom / xml / exceptions を分離
- ``DomEvent`` は frozen dataclass．``Tag()`` / ``Attrib()`` / ``Terminator()`` のファクトリ関数も提供
- 巨大 DOM を O(chunk) で流す設計．ワンショット ``build_xml`` は小〜中規模向け

### 実データ検証（sample.a7s 173MB）

- ``detect_version`` → V3 確定
- ``parse_tag_section`` → tags=465 / attribs=558（調査 doc と一致）
- 先頭 20 event で ``MetaGameManager`` → ``NetworkSafeRandom`` → ``FunFactSettings`` が正しく yield される
- Attrib content の 8B padding も正確

## Test plan

- [x] ``pytest --cov=anno_save_analyzer --cov-branch --cov-fail-under=100`` → **101 tests passed, 100.0%**
  - RDA 既存 45 件
  - FileDB 新規 56 件（version 10 / dictionary 10 / dom 15 / xml 13 ほか）
- [x] ``ruff check`` / ``ruff format --check`` → clean
- [ ] GitHub Actions で同基準通過確認

## Progress vs. v0.2 scope

- #9 (FileDB V3 parser): ``parser.filedb`` 配下を実装してほぼ完了．Anno 117 smoke test は後続コミット or 別 PR で追加
- #10 (Pydantic model 層): 未着手（別ブランチで対応予定）

Refs #9

## Reviewer notes

- Copilot: dom.py の state 判定 (``id ≥ 32768`` / ``id ≤ 0``) と block padding の境界を中心にレビューして
- 人間レビュアー: lxml の element 表現がこれで十分か，``hex`` 属性方式 vs base64 / raw bytes の選択判断

## License / 3rd party

- 仕様のみ [FileDBReader](https://github.com/anno-mods/FileDBReader) (GPL-v3) を参照．コード転載なし
- ``refs/FileDBReader`` は ``.gitignore`` 済でローカル参照のみ
- 謝辞は ``docs/filedb_format_investigation.md`` に記載

## Milestone

v0.2