### PR TITLE
refactor(tui): expose `Screen.set_localizer` instead of writing to private attr

### DIFF
--- a/src/anno_save_analyzer/tui/app.py
+++ b/src/anno_save_analyzer/tui/app.py
@@ -91,7 +91,7 @@ class TradeApp(App[None]):
         self._apply_localized_bindings()
         self.title = self._localized_title()
         for screen in (self.get_screen("overview"), self.get_screen("statistics")):
-            screen._localizer = self._localizer
+            screen.set_localizer(self._localizer)
             screen.refresh(recompose=True)
 
     def action_show_help(self) -> None:  # pragma: no cover - manual interaction only

--- a/src/anno_save_analyzer/tui/screens/overview.py
+++ b/src/anno_save_analyzer/tui/screens/overview.py
@@ -19,6 +19,15 @@ class OverviewScreen(Screen):
         self._state = state
         self._localizer = localizer
 
+    def set_localizer(self, localizer: Localizer) -> None:
+        """``TradeApp.switch_locale`` から呼ばれる公開 setter．
+
+        ``_localizer`` は private 属性だが App が locale 切替で書き換える
+        必要があるので，直書きせずこの setter 経由にする．実装は差し替え
+        のみで，再描画はコール側の ``refresh(recompose=True)`` に任せる．
+        """
+        self._localizer = localizer
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield VerticalScroll(self._render_body())

--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -57,6 +57,14 @@ class TradeStatisticsScreen(Screen):
         self._state = state
         self._localizer = localizer
 
+    def set_localizer(self, localizer: Localizer) -> None:
+        """``TradeApp.switch_locale`` から呼ばれる公開 setter．
+
+        ``_localizer`` の直書き回避．再描画はコール側の ``refresh(recompose=True)``
+        に委譲する．
+        """
+        self._localizer = localizer
+
     def compose(self) -> ComposeResult:
         t = self._localizer.t
         yield Header()

--- a/tests/tui/test_screens.py
+++ b/tests/tui/test_screens.py
@@ -11,6 +11,35 @@ from anno_save_analyzer.tui.state import TuiState, build_overview
 
 
 @pytest.mark.asyncio
+class TestScreenLocalizerSetter:
+    """Cursor レビュー指摘: App からの ``_localizer`` 直書きを setter 化．"""
+
+    async def test_overview_set_localizer_swaps_instance(self, tui_state) -> None:
+        from anno_save_analyzer.tui.screens import OverviewScreen
+
+        app = TradeApp(tui_state)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            overview = pilot.app.get_screen("overview")
+            assert isinstance(overview, OverviewScreen)
+            new_localizer = Localizer.load("ja")
+            overview.set_localizer(new_localizer)
+            assert overview._localizer is new_localizer
+
+    async def test_statistics_set_localizer_swaps_instance(self, tui_state) -> None:
+        from anno_save_analyzer.tui.screens import TradeStatisticsScreen
+
+        app = TradeApp(tui_state)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            stats = pilot.app.get_screen("statistics")
+            assert isinstance(stats, TradeStatisticsScreen)
+            new_localizer = Localizer.load("ja")
+            stats.set_localizer(new_localizer)
+            assert stats._localizer is new_localizer
+
+
+@pytest.mark.asyncio
 class TestOverviewScreen:
     async def test_overview_renders_with_session_ids(self, tui_state) -> None:
         app = TradeApp(tui_state)


### PR DESCRIPTION
## Summary (EN)

Address Cursor code review finding #2: ``TradeApp.switch_locale`` was writing directly to the installed screens' ``_localizer`` attribute, breaking encapsulation. Add a public ``set_localizer(localizer: Localizer)`` on both ``OverviewScreen`` and ``TradeStatisticsScreen`` and route the app through it. Redraw stays the caller's responsibility (``refresh(recompose=True)``).

No functional change — ``^L`` / ``switch_locale`` still swap locales the same way.

## 概要 (JA)

Cursor レビュー指摘 #2 対応．``TradeApp.switch_locale`` が ``screen._localizer`` に直書きしていた部分をカプセル化し，Screen 側に公開 setter ``set_localizer`` を追加．App はそれ経由で差し替える．動作は不変．

## Test plan

- [x] ``pytest --cov=anno_save_analyzer --cov-branch --cov-fail-under=100`` — 340 passed / 100% coverage
- [x] ``ruff check`` / ``ruff format --check`` clean
- [x] Overview / Statistics 両画面に setter 直接呼出の新規テスト追加
- [x] 既存の ``^L`` / ``switch_locale`` テストは同じパスを通って緑

## Cursor notes (original)

> TradeApp.switch_locale が screen._localizer を直書き — 画面の「プライベート属性」を App が触ってるので、カプセル化はやや割れてる（Textual の制約回避としては理解できる）。