### PR TITLE
feat(trade): Phase 1 — island_name on TradeEvent + session/island filters

### DIFF
--- a/src/anno_save_analyzer/cli/trade.py
+++ b/src/anno_save_analyzer/cli/trade.py
@@ -89,8 +89,7 @@ def list_trades(
     """List every TradeEvent extracted from SAVE."""
     _ensure_format_supported(fmt)
     title_v = title.to_title()
-    events = list(_events(save, title_v, locale))
-    events = filter_events(events, session=session, island=island)
+    events = filter_events(_events(save, title_v, locale), session=session, island=island)
     payload = [
         {
             "timestamp_tick": ev.timestamp_tick,

--- a/src/anno_save_analyzer/cli/trade.py
+++ b/src/anno_save_analyzer/cli/trade.py
@@ -19,6 +19,7 @@ from anno_save_analyzer.trade import (
     diff_by_route,
     extract,
 )
+from anno_save_analyzer.trade.aggregate import filter_events
 from anno_save_analyzer.trade.models import TradeEvent
 
 trade_app = typer.Typer(help="Inspect trade activity inside a save file.")
@@ -75,6 +76,12 @@ def list_trades(
         GameTitleArg, typer.Option("--title", help="Game title.")
     ] = GameTitleArg.ANNO_117,
     locale: Annotated[str, typer.Option("--locale", help="Display locale.")] = "en",
+    session: Annotated[
+        str | None, typer.Option("--session", help="Filter by session id (e.g. '0' / '1').")
+    ] = None,
+    island: Annotated[
+        str | None, typer.Option("--island", help="Filter by island (CityName).")
+    ] = None,
     fmt: Annotated[
         OutputFormat, typer.Option("--format", help="Output format.")
     ] = OutputFormat.JSON,
@@ -83,6 +90,7 @@ def list_trades(
     _ensure_format_supported(fmt)
     title_v = title.to_title()
     events = list(_events(save, title_v, locale))
+    events = filter_events(events, session=session, island=island)
     payload = [
         {
             "timestamp_tick": ev.timestamp_tick,
@@ -104,6 +112,7 @@ def list_trades(
             ),
             "route_id": ev.route_id,
             "session_id": ev.session_id,
+            "island_name": ev.island_name,
             "source_method": ev.source_method,
         }
         for ev in events
@@ -119,6 +128,12 @@ def summary(
         GameTitleArg, typer.Option("--title", help="Game title.")
     ] = GameTitleArg.ANNO_117,
     locale: Annotated[str, typer.Option("--locale", help="Display locale.")] = "en",
+    session: Annotated[
+        str | None, typer.Option("--session", help="Filter by session id (e.g. '0' / '1').")
+    ] = None,
+    island: Annotated[
+        str | None, typer.Option("--island", help="Filter by island (CityName).")
+    ] = None,
     fmt: Annotated[
         OutputFormat, typer.Option("--format", help="Output format.")
     ] = OutputFormat.JSON,
@@ -128,7 +143,7 @@ def summary(
     title_v = title.to_title()
     events = _events(save, title_v, locale)
     if by is SummaryAxis.ITEM:
-        item_rows = by_item(events)
+        item_rows = by_item(events, session=session, island=island)
         _emit_json(
             [
                 {
@@ -146,7 +161,7 @@ def summary(
             ]
         )
         return
-    route_rows = by_route(events)
+    route_rows = by_route(events, session=session, island=island)
     _emit_json(
         [
             {
@@ -172,6 +187,12 @@ def diff(
         GameTitleArg, typer.Option("--title", help="Game title.")
     ] = GameTitleArg.ANNO_117,
     locale: Annotated[str, typer.Option("--locale", help="Display locale.")] = "en",
+    session: Annotated[
+        str | None, typer.Option("--session", help="Filter by session id (e.g. '0' / '1').")
+    ] = None,
+    island: Annotated[
+        str | None, typer.Option("--island", help="Filter by island (CityName).")
+    ] = None,
     fmt: Annotated[
         OutputFormat, typer.Option("--format", help="Output format.")
     ] = OutputFormat.JSON,
@@ -189,7 +210,7 @@ def diff(
     before_events = list(_events(before, title_v, locale))
     after_events = list(_events(after, title_v, locale))
     if by is SummaryAxis.ITEM:
-        rows = diff_by_item(before_events, after_events)
+        rows = diff_by_item(before_events, after_events, session=session, island=island)
         if not show_unchanged:
             rows = [r for r in rows if r.status != "unchanged"]
         _emit_json(
@@ -208,7 +229,7 @@ def diff(
             ]
         )
         return
-    route_rows = diff_by_route(before_events, after_events)
+    route_rows = diff_by_route(before_events, after_events, session=session, island=island)
     if not show_unchanged:
         route_rows = [r for r in route_rows if r.status != "unchanged"]
     _emit_json(

--- a/src/anno_save_analyzer/trade/aggregate.py
+++ b/src/anno_save_analyzer/trade/aggregate.py
@@ -10,6 +10,27 @@ from pydantic import BaseModel
 from .models import Item, Locale, TradeEvent
 
 
+def filter_events(
+    events: Iterable[TradeEvent],
+    *,
+    session: str | None = None,
+    island: str | None = None,
+) -> list[TradeEvent]:
+    """session / island 粒度で TradeEvent stream を絞る．
+
+    両方 ``None`` なら全量 (listify のみ)．両方指定時は AND．TUI の Tree
+    選択や CLI ``--session`` / ``--island`` の共通入口．
+    """
+    out: list[TradeEvent] = []
+    for ev in events:
+        if session is not None and ev.session_id != session:
+            continue
+        if island is not None and ev.island_name != island:
+            continue
+        out.append(ev)
+    return out
+
+
 class ItemSummary(BaseModel):
     """物資別集計．"""
 
@@ -68,8 +89,18 @@ class PartnerSummary(BaseModel):
         return "—"
 
 
-def by_item(events: Iterable[TradeEvent]) -> list[ItemSummary]:
-    """物資別に集計する．event_count 降順 → guid 昇順で安定ソート．"""
+def by_item(
+    events: Iterable[TradeEvent],
+    *,
+    session: str | None = None,
+    island: str | None = None,
+) -> list[ItemSummary]:
+    """物資別に集計する．event_count 降順 → guid 昇順で安定ソート．
+
+    ``session`` / ``island`` が指定されていればその粒度で pre-filter する．
+    """
+    if session is not None or island is not None:
+        events = filter_events(events, session=session, island=island)
     buckets: dict[int, dict] = {}
     item_lookup: dict[int, Item] = {}
     for ev in events:
@@ -103,8 +134,18 @@ def by_item(events: Iterable[TradeEvent]) -> list[ItemSummary]:
     return summaries
 
 
-def by_route(events: Iterable[TradeEvent]) -> list[RouteSummary]:
-    """ルート / partner kind 別に集計．`(route_id, partner_kind)` キー．"""
+def by_route(
+    events: Iterable[TradeEvent],
+    *,
+    session: str | None = None,
+    island: str | None = None,
+) -> list[RouteSummary]:
+    """ルート / partner kind 別に集計．`(route_id, partner_kind)` キー．
+
+    ``session`` / ``island`` が指定されていればその粒度で pre-filter する．
+    """
+    if session is not None or island is not None:
+        events = filter_events(events, session=session, island=island)
     buckets: dict[tuple[str | None, str], dict] = defaultdict(
         lambda: {
             "bought": 0,
@@ -137,12 +178,21 @@ def by_route(events: Iterable[TradeEvent]) -> list[RouteSummary]:
     return summaries
 
 
-def partners_for_item(events: Iterable[TradeEvent], item_guid: int) -> list[PartnerSummary]:
+def partners_for_item(
+    events: Iterable[TradeEvent],
+    item_guid: int,
+    *,
+    session: str | None = None,
+    island: str | None = None,
+) -> list[PartnerSummary]:
     """指定 item GUID の取引を (route_id, partner_id, kind) 別に集計．
 
     物資を選んだときの Partners pane に出す "この物資を誰と取引したか" を
     event_count 降順 → abs(net_gold) 降順 → route_id 昇順で返す．
+    ``session`` / ``island`` 指定で絞り込み可能．
     """
+    if session is not None or island is not None:
+        events = filter_events(events, session=session, island=island)
     buckets: dict[tuple[str | None, str | None, str], dict] = defaultdict(
         lambda: {
             "bought": 0,

--- a/src/anno_save_analyzer/trade/diff.py
+++ b/src/anno_save_analyzer/trade/diff.py
@@ -68,10 +68,16 @@ def _classify(before_count: int, after_count: int, nonzero_delta: bool) -> str:
 def diff_by_item(
     before: Iterable[TradeEvent],
     after: Iterable[TradeEvent],
+    *,
+    session: str | None = None,
+    island: str | None = None,
 ) -> list[ItemDelta]:
-    """物資別に before / after を集計し delta を算出．event_count 降順 → guid 昇順で返す．"""
-    b_summaries = {s.item.guid: s for s in by_item(before)}
-    a_summaries = {s.item.guid: s for s in by_item(after)}
+    """物資別に before / after を集計し delta を算出．event_count 降順 → guid 昇順で返す．
+
+    ``session`` / ``island`` 指定で両サイドを filter してから diff する．
+    """
+    b_summaries = {s.item.guid: s for s in by_item(before, session=session, island=island)}
+    a_summaries = {s.item.guid: s for s in by_item(after, session=session, island=island)}
     guids = sorted(set(b_summaries) | set(a_summaries))
     deltas: list[ItemDelta] = []
     for guid in guids:
@@ -107,10 +113,20 @@ def diff_by_item(
 def diff_by_route(
     before: Iterable[TradeEvent],
     after: Iterable[TradeEvent],
+    *,
+    session: str | None = None,
+    island: str | None = None,
 ) -> list[RouteDelta]:
-    """ルート × partner_kind 別の delta．キーは ``(route_id, partner_kind)``．"""
-    b_summaries = {(s.route_id, s.partner_kind): s for s in by_route(before)}
-    a_summaries = {(s.route_id, s.partner_kind): s for s in by_route(after)}
+    """ルート × partner_kind 別の delta．キーは ``(route_id, partner_kind)``．
+
+    ``session`` / ``island`` 指定で両サイドを filter してから diff する．
+    """
+    b_summaries = {
+        (s.route_id, s.partner_kind): s for s in by_route(before, session=session, island=island)
+    }
+    a_summaries = {
+        (s.route_id, s.partner_kind): s for s in by_route(after, session=session, island=island)
+    }
     keys = sorted(set(b_summaries) | set(a_summaries), key=lambda k: (k[0] or "", k[1]))
     deltas: list[RouteDelta] = []
     for key in keys:

--- a/src/anno_save_analyzer/trade/exports.py
+++ b/src/anno_save_analyzer/trade/exports.py
@@ -100,13 +100,14 @@ def routes_to_csv(
 def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str:
     """個別 TradeEvent を CSV にエクスポート (ledger 全量)．
 
-    列: timestamp_tick, session_id, route_id, partner_id, partner_kind,
-         item_guid, item_name, amount, total_price
+    列: timestamp_tick, session_id, island_name, route_id, partner_id,
+         partner_kind, item_guid, item_name, amount, total_price
     """
     rows: list[list[str]] = [
         [
             "timestamp_tick",
             "session_id",
+            "island_name",
             "route_id",
             "partner_id",
             "partner_kind",
@@ -123,6 +124,7 @@ def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str
             [
                 "" if ev.timestamp_tick is None else str(ev.timestamp_tick),
                 ev.session_id or "",
+                ev.island_name or "",
                 ev.route_id or "",
                 partner_id,
                 partner_kind,
@@ -143,6 +145,7 @@ def events_to_json(events: Iterable[TradeEvent], *, locale: Locale = "en") -> st
             {
                 "timestamp_tick": ev.timestamp_tick,
                 "session_id": ev.session_id,
+                "island_name": ev.island_name,
                 "route_id": ev.route_id,
                 "partner": ({"id": ev.partner.id, "kind": ev.partner.kind} if ev.partner else None),
                 "item": {

--- a/src/anno_save_analyzer/trade/extract.py
+++ b/src/anno_save_analyzer/trade/extract.py
@@ -50,6 +50,7 @@ def normalise(
         partner=partner,
         route_id=raw.context.route_id,
         session_id=raw.context.session_id,
+        island_name=raw.context.island_name,
         source_method="history",
     )
 

--- a/src/anno_save_analyzer/trade/interpreter/anno117.py
+++ b/src/anno_save_analyzer/trade/interpreter/anno117.py
@@ -92,6 +92,7 @@ def _walk_inner_session(inner: bytes, session_idx: int) -> Iterator[RawTradedGoo
     in_area_info_depth = -1  # AreaInfo タグに入った時点の tag_stack 長
     area_entry_depth = -1  # 直下 <1> エントリの tag_stack 長
     in_player_island = False
+    current_island_name: str | None = None  # 現在の AreaInfo entry の CityName
 
     # TradedGoods が置かれる「inner <1> エントリ」の深さ．ここに Trader /
     # ExecutionTime / RouteID 等の attribs が載る．ただし順序的に TradedGoods
@@ -119,6 +120,7 @@ def _walk_inner_session(inner: bytes, session_idx: int) -> Iterator[RawTradedGoo
                 # 新しい AreaInfo > <1> エントリ開始
                 area_entry_depth = len(tag_stack)
                 in_player_island = False
+                current_island_name = None
 
             if name == _TRADED_GOODS_TAG:
                 kind = _classify_parent(tag_stack)
@@ -142,13 +144,22 @@ def _walk_inner_session(inner: bytes, session_idx: int) -> Iterator[RawTradedGoo
             if attrib_stack:
                 attrib_stack[-1][ev.name or f"<{ev.id_}>"] = ev.content
 
-            # AreaInfo > <1> 直下に CityName があるならプレイヤー保有島と判定
+            # AreaInfo > <1> 直下に CityName があるならプレイヤー保有島と判定．
+            # UTF-16-LE で末尾 null を剥いて島名として保持．書記長の save では
+            # "​スターリングラード" のように先頭に U+200B (zero-width space) が混ざる
+            # ケースが実測されたため strip 対象に含める．
             if (
                 area_entry_depth >= 0
                 and len(tag_stack) == area_entry_depth
                 and ev.name == _CITY_NAME_ATTRIB
             ):
                 in_player_island = True
+                current_island_name = (
+                    ev.content.decode("utf-16-le", errors="replace")
+                    .rstrip("\x00")
+                    .replace("\u200b", "")
+                    .strip()
+                )
 
             if in_traded_goods and traded_goods_depth >= 1:
                 # TradedGoods 直下の child (<1>) 配下に GoodGuid / GoodAmount / TotalPrice
@@ -177,6 +188,7 @@ def _walk_inner_session(inner: bytes, session_idx: int) -> Iterator[RawTradedGoo
                     session_id=session_id,
                     kind=kind,
                     ancestor_attribs=attrib_stack,
+                    island_name=current_island_name,
                 )
                 if triple is not None:
                     yield triple
@@ -192,6 +204,7 @@ def _walk_inner_session(inner: bytes, session_idx: int) -> Iterator[RawTradedGoo
         if area_entry_depth >= 0 and closing_depth == area_entry_depth:
             area_entry_depth = -1
             in_player_island = False
+            current_island_name = None
         if in_area_info_depth >= 0 and closing_depth == in_area_info_depth:
             in_area_info_depth = -1
 
@@ -240,6 +253,7 @@ def _build_triple_if_complete(
     session_id: str,
     kind: PartnerKind,
     ancestor_attribs: list[dict[str, bytes]],
+    island_name: str | None = None,
 ) -> RawTradedGoodTriple | None:
     if triple["good_guid"] is None or triple["amount"] is None:
         return None
@@ -272,6 +286,7 @@ def _build_triple_if_complete(
             partner_id=partner_id,
             partner_kind=kind,
             timestamp_tick=timestamp_tick,
+            island_name=island_name,
         ),
     )
 

--- a/src/anno_save_analyzer/trade/interpreter/base.py
+++ b/src/anno_save_analyzer/trade/interpreter/base.py
@@ -26,6 +26,12 @@ class ExtractionContext:
     partner_id: str | None = None
     partner_kind: PartnerKind = "unknown"
     timestamp_tick: int | None = None
+    island_name: str | None = None
+    """プレイヤー保有島の ``CityName``．NPC 島は事前に filter されているので
+    ここに載るのは全てプレイヤー所有．interpreter が AreaInfo > <1> walk 時に
+    attach する．Anno 117 で実測．Anno 1800 でも同構造なら取れるはず (v0.3.1 は
+    117 のみ対象)．
+    """
 
 
 @dataclass(frozen=True)

--- a/src/anno_save_analyzer/trade/models.py
+++ b/src/anno_save_analyzer/trade/models.py
@@ -70,6 +70,11 @@ class TradeEvent(BaseModel):
     partner: TradingPartner | None = None
     route_id: str | None = None
     session_id: str | None = None
+    island_name: str | None = None
+    """この取引が帰属するプレイヤー保有島の ``CityName``．NPC 同士の取引は
+    interpreter 側で除外済みのためここに載るのは全てプレイヤー所有．
+    TUI 側の Tree filter (島単位 / セッション単位) の key．
+    """
     source_method: SourceMethod = "history"
 
     model_config = {"frozen": True}

--- a/tests/cli/test_trade.py
+++ b/tests/cli/test_trade.py
@@ -213,6 +213,119 @@ class TestTradeDiffCommand:
         assert isinstance(result.exception, NotImplementedError)
 
 
+class TestIslandAndSessionFilters:
+    """#29 Phase 1: ``--island`` / ``--session`` filter を受ける．"""
+
+    def _save_with_islands(self, tmp_path: Path) -> Path:
+        # conftest の make_inner_filedb は `プレイヤー島` 一律で付くので
+        # それを使って全イベントに island_name="プレイヤー島" が載る前提．
+        save = _make_save(tmp_path)
+        return save
+
+    def test_list_with_island_filter_returns_subset(self, tmp_path: Path) -> None:
+        save = self._save_with_islands(tmp_path)
+        # fixture は全件 "プレイヤー島" なので指定で全件残る
+        r = runner.invoke(
+            app, ["trade", "list", str(save), "--title", "anno117", "--island", "プレイヤー島"]
+        )
+        assert r.exit_code == 0, r.output
+        payload = json.loads(r.stdout)
+        assert len(payload) == 3
+        # 存在しない島を指定すると空
+        r2 = runner.invoke(
+            app, ["trade", "list", str(save), "--title", "anno117", "--island", "存在しない島"]
+        )
+        assert r2.exit_code == 0
+        assert json.loads(r2.stdout) == []
+
+    def test_list_exposes_island_name_in_json(self, tmp_path: Path) -> None:
+        save = self._save_with_islands(tmp_path)
+        r = runner.invoke(app, ["trade", "list", str(save), "--title", "anno117"])
+        assert r.exit_code == 0
+        payload = json.loads(r.stdout)
+        assert all(p["island_name"] == "プレイヤー島" for p in payload)
+
+    def test_summary_respects_island(self, tmp_path: Path) -> None:
+        save = self._save_with_islands(tmp_path)
+        r = runner.invoke(
+            app,
+            [
+                "trade",
+                "summary",
+                str(save),
+                "--title",
+                "anno117",
+                "--by",
+                "item",
+                "--island",
+                "存在しない島",
+            ],
+        )
+        assert r.exit_code == 0
+        # 指定島に該当なし → 空集計
+        assert json.loads(r.stdout) == []
+
+    def test_summary_by_route_with_session(self, tmp_path: Path) -> None:
+        save = self._save_with_islands(tmp_path)
+        # session_id 0 だけ指定．fixture は 1 session なので全件保持．
+        r = runner.invoke(
+            app,
+            [
+                "trade",
+                "summary",
+                str(save),
+                "--title",
+                "anno117",
+                "--by",
+                "route",
+                "--session",
+                "0",
+            ],
+        )
+        assert r.exit_code == 0
+        rows = json.loads(r.stdout)
+        assert len(rows) >= 1
+
+    def test_diff_respects_island_filter(self, tmp_path: Path) -> None:
+        (tmp_path / "b").mkdir(exist_ok=True)
+        before = self._save_with_islands(tmp_path / "b")
+        # 同じ save を 2 つ渡すと全 unchanged．island 一致なら行が出る (--show-unchanged)．
+        r = runner.invoke(
+            app,
+            [
+                "trade",
+                "diff",
+                str(before),
+                str(before),
+                "--title",
+                "anno117",
+                "--island",
+                "プレイヤー島",
+                "--show-unchanged",
+            ],
+        )
+        assert r.exit_code == 0
+        rows = json.loads(r.stdout)
+        assert len(rows) >= 1
+        # 違う島だと空
+        r2 = runner.invoke(
+            app,
+            [
+                "trade",
+                "diff",
+                str(before),
+                str(before),
+                "--title",
+                "anno117",
+                "--island",
+                "存在しない島",
+                "--show-unchanged",
+            ],
+        )
+        assert r2.exit_code == 0
+        assert json.loads(r2.stdout) == []
+
+
 class TestTopLevelHelp:
     def test_no_args_shows_help_and_exits_nonzero(self) -> None:
         result = runner.invoke(app, [])

--- a/tests/trade/test_aggregate.py
+++ b/tests/trade/test_aggregate.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from anno_save_analyzer.trade.aggregate import by_item, by_route, partners_for_item
+from anno_save_analyzer.trade.aggregate import (
+    by_item,
+    by_route,
+    filter_events,
+    partners_for_item,
+)
 from anno_save_analyzer.trade.models import Item, TradeEvent, TradingPartner
 
 
@@ -15,6 +20,8 @@ def _ev(
     kind: str = "unknown",
     timestamp: int | None = None,
     partner: TradingPartner | None | object = ...,
+    session_id: str | None = None,
+    island_name: str | None = None,
 ) -> TradeEvent:
     item = Item(guid=guid, names={"en": f"Good_{guid}"})
     # partner = sentinel (...) なら kind と route_id から自動生成．
@@ -28,6 +35,8 @@ def _ev(
         partner=partner,
         route_id=route_id,
         timestamp_tick=timestamp,
+        session_id=session_id,
+        island_name=island_name,
     )
 
 
@@ -193,3 +202,67 @@ class TestPartnersForItem:
         events = [_ev(100, 1, 10, route_id="r")]
         rows = partners_for_item(events, 100)
         assert rows[0].display_name("en") == "Good_100"
+
+
+class TestFilterEvents:
+    def test_no_filter_returns_all(self) -> None:
+        events = [_ev(1, 1, 1, session_id="0", island_name="A"), _ev(2, 1, 1, session_id="1")]
+        assert len(filter_events(events)) == 2
+
+    def test_filter_by_session(self) -> None:
+        events = [
+            _ev(1, 1, 1, session_id="0"),
+            _ev(2, 1, 1, session_id="1"),
+            _ev(3, 1, 1, session_id="0"),
+        ]
+        out = filter_events(events, session="0")
+        assert len(out) == 2
+        assert all(e.session_id == "0" for e in out)
+
+    def test_filter_by_island(self) -> None:
+        events = [
+            _ev(1, 1, 1, island_name="大阪民国"),
+            _ev(2, 1, 1, island_name="ジョウト地方"),
+        ]
+        out = filter_events(events, island="大阪民国")
+        assert len(out) == 1
+        assert out[0].island_name == "大阪民国"
+
+    def test_filter_session_and_island_are_anded(self) -> None:
+        events = [
+            _ev(1, 1, 1, session_id="0", island_name="A"),
+            _ev(2, 1, 1, session_id="0", island_name="B"),
+            _ev(3, 1, 1, session_id="1", island_name="A"),
+        ]
+        out = filter_events(events, session="0", island="A")
+        assert len(out) == 1
+        assert out[0].item.guid == 1
+
+
+class TestAggregateFilterArgs:
+    def test_by_item_with_island_filter(self) -> None:
+        events = [
+            _ev(100, 5, 50, island_name="Osaka"),
+            _ev(100, 3, 30, island_name="Gunma"),
+        ]
+        rows = by_item(events, island="Osaka")
+        assert len(rows) == 1
+        assert rows[0].bought == 5
+
+    def test_by_route_with_session_filter(self) -> None:
+        events = [
+            _ev(1, 1, 10, route_id="A", kind="route", session_id="0"),
+            _ev(1, 1, 10, route_id="A", kind="route", session_id="1"),
+        ]
+        rows = by_route(events, session="0")
+        assert len(rows) == 1
+        assert rows[0].event_count == 1
+
+    def test_partners_for_item_with_island_filter(self) -> None:
+        events = [
+            _ev(100, 1, 10, route_id="A", island_name="X"),
+            _ev(100, 1, 10, route_id="B", island_name="Y"),
+        ]
+        rows = partners_for_item(events, 100, island="X")
+        assert len(rows) == 1
+        assert rows[0].route_id == "A"

--- a/tests/trade/test_diff.py
+++ b/tests/trade/test_diff.py
@@ -13,6 +13,8 @@ def _ev(
     *,
     route_id: str | None = None,
     kind: str = "route",
+    session_id: str | None = None,
+    island_name: str | None = None,
 ) -> TradeEvent:
     return TradeEvent(
         item=Item(guid=guid, names={"en": f"Good_{guid}"}),
@@ -20,6 +22,8 @@ def _ev(
         total_price=price,
         partner=TradingPartner(id=route_id or "anon", display_name="x", kind=kind),
         route_id=route_id,
+        session_id=session_id,
+        island_name=island_name,
     )
 
 
@@ -123,3 +127,30 @@ class TestDiffByRoute:
 
     def test_empty_returns_empty(self) -> None:
         assert diff_by_route([], []) == []
+
+
+class TestDiffFilterArgs:
+    def test_diff_by_item_filters_both_sides(self) -> None:
+        before = [
+            _ev(1, 1, 10, route_id="A", island_name="X"),
+            _ev(1, 1, 10, route_id="A", island_name="Y"),
+        ]
+        after = [
+            _ev(1, 3, 30, route_id="A", island_name="X"),
+            _ev(1, 1, 10, route_id="A", island_name="Y"),
+        ]
+        # 島 X だけ見ると Δ buy=+2，Y は unchanged
+        rows = diff_by_item(before, after, island="X")
+        assert len(rows) == 1
+        assert rows[0].bought_delta == 2
+        assert rows[0].status == "changed"
+
+    def test_diff_by_route_filters_by_session(self) -> None:
+        before = [_ev(1, 1, 10, route_id="A", session_id="0")]
+        after = [
+            _ev(1, 3, 30, route_id="A", session_id="0"),
+            _ev(1, 1, 10, route_id="A", session_id="1"),  # 別 session は無視
+        ]
+        rows = diff_by_route(before, after, session="0")
+        assert len(rows) == 1
+        assert rows[0].bought_delta == 2

--- a/tests/trade/test_exports.py
+++ b/tests/trade/test_exports.py
@@ -194,11 +194,13 @@ class TestEventsToCsvAndJson:
         ]
         out = events_to_csv(events)
         rows = list(csv.reader(io.StringIO(out)))
-        # column order: timestamp_tick, session_id, route_id, partner_id,
-        #               partner_kind, item_guid, item_name, amount, total_price
+        # column order: timestamp_tick, session_id, island_name, route_id,
+        #               partner_id, partner_kind, item_guid, item_name,
+        #               amount, total_price
         assert rows[0] == [
             "timestamp_tick",
             "session_id",
+            "island_name",
             "route_id",
             "partner_id",
             "partner_kind",
@@ -208,10 +210,10 @@ class TestEventsToCsvAndJson:
             "total_price",
         ]
         assert rows[1][0] == "100"  # timestamp
-        assert rows[1][5] == "100"  # item_guid
+        assert rows[1][6] == "100"  # item_guid
         # 2 行目 partner=None
-        assert rows[2][3] == ""
-        assert rows[2][4] == ""
+        assert rows[2][4] == ""  # partner_id
+        assert rows[2][5] == ""  # partner_kind
         # timestamp 無し
         assert rows[2][0] == ""
 
@@ -236,3 +238,17 @@ class TestEventsToCsvAndJson:
         events = [self._ev(guid=100)]
         out = events_to_json(events, locale="ja")
         assert "品100" in out  # ensure_ascii=False なので生の日本語が出る
+
+    def test_events_csv_includes_island_name(self) -> None:
+        events = [
+            self._ev(route_id="7", session_id="0", timestamp_tick=100, island_name="大阪民国")
+        ]
+        out = events_to_csv(events)
+        rows = list(csv.reader(io.StringIO(out)))
+        # island_name 列は index 2
+        assert rows[1][2] == "大阪民国"
+
+    def test_events_json_includes_island_name(self) -> None:
+        events = [self._ev(island_name="Osaka")]
+        parsed = json.loads(events_to_json(events))
+        assert parsed[0]["island_name"] == "Osaka"

--- a/tests/trade/test_interpreter_anno117.py
+++ b/tests/trade/test_interpreter_anno117.py
@@ -400,6 +400,71 @@ class TestNpcIslandFiltering:
         assert len(triples) == 2
 
 
+class TestIslandNameAttachment:
+    """#29 Phase 1: AreaInfo entry の CityName が ExtractionContext.island_name に載る．"""
+
+    def test_island_name_populated_on_raw_triples(self) -> None:
+        from .conftest import make_inner_filedb, wrap_as_outer
+
+        inner = make_inner_filedb({"route": [(7, 100, 5, 0), (7, 200, -3, 0)]})
+        outer = wrap_as_outer([inner])
+        section = parse_tag_section(outer, detect_version(outer))
+        triples = list(Anno117Interpreter().find_traded_goods(outer, section))
+        # fixture の CityName は "プレイヤー島" 固定
+        assert {t.context.island_name for t in triples} == {"プレイヤー島"}
+
+    def test_zero_width_space_and_padding_stripped(self) -> None:
+        """CityName に U+200B が混ざる実セーブケース → strip される．"""
+        import struct
+
+        from tests.parser.filedb.conftest import minimal_v3
+
+        tags = {
+            2: "PassiveTrade",
+            3: "History",
+            4: "TradeRouteEntries",
+            5: "TradedGoods",
+            6: "AreaInfo",
+        }
+        attribs = {
+            0x8001: "RouteID",
+            0x8002: "GoodGuid",
+            0x8003: "GoodAmount",
+            0x8004: "TotalPrice",
+            0x8005: "CityName",
+        }
+        events = [
+            ("T", 6),  # AreaInfo
+            ("T", 1),  # entry
+            ("A", 0x8005, "\u200bスターリングラード".encode("utf-16-le")),
+            ("T", 2),
+            ("T", 3),
+            ("T", 4),
+            ("T", 1),  # outer <1>
+            ("T", 1),  # inner <1>
+            ("A", 0x8001, struct.pack("<i", 42)),
+            ("T", 5),
+            ("T", 1),
+            ("A", 0x8002, struct.pack("<i", 100)),
+            ("A", 0x8003, struct.pack("<i", 1)),
+            ("X",),
+            ("X",),  # close TradedGoods
+            ("X",),  # inner <1>
+            ("X",),  # outer <1>
+            ("X",),  # TradeRouteEntries
+            ("X",),  # History
+            ("X",),  # PassiveTrade
+            ("X",),  # AreaInfo > <1>
+            ("X",),  # AreaInfo
+        ]
+        inner = minimal_v3(tags=tags, attribs=attribs, events=events)
+        outer = wrap_as_outer([inner])
+        section = parse_tag_section(outer, detect_version(outer))
+        triples = list(Anno117Interpreter().find_traded_goods(outer, section))
+        assert len(triples) == 1
+        assert triples[0].context.island_name == "スターリングラード"
+
+
 class TestRootLevelAttribsAndTerminators:
     """外側 FileDB の root レベルに attrib / 余分 terminator がある DOM を扱える．"""
 


### PR DESCRIPTION
Closes #29 (Phase 1 half). Prerequisite for #23 (v0.4 inventory integration) and #30 (Phase 2 TUI Tree filter).

## Summary (EN)

Trade pipeline now carries per-island provenance end-to-end so CLI / library consumers can filter at the island or session granularity.

### Data layer
- ``ExtractionContext`` gains ``island_name: str | None``
- ``Anno117Interpreter`` captures the current ``AreaInfo > <1> > CityName`` during the walk and attaches it to each yielded triple. Zero-width spaces (U+200B, observed on real save e.g. ``スターリングラード``) are stripped
- ``TradeEvent.island_name`` field; ``extract.normalise`` propagates it

### Aggregation / diff
- New ``filter_events(events, *, session, island)`` helper
- ``by_item`` / ``by_route`` / ``partners_for_item`` / ``diff_by_item`` / ``diff_by_route`` accept ``session=`` / ``island=`` kwargs

### CLI
- ``trade list`` / ``summary`` / ``diff`` gain ``--session`` and ``--island`` options; JSON includes ``island_name`` per row

### Exports
- ``events_to_csv`` / ``events_to_json`` include ``island_name``

## 概要 (JA)

TradeEvent まで島名 (CityName) を伝搬させ，aggregate / CLI / export で island / session フィルタが効くようにした．#23 (v0.4 在庫推移) と #30 (Phase 2 TUI Tree filter) の前提．

- interpreter: AreaInfo 走査中に CityName を拾って triple に attach．書記長の実セーブで見つかった U+200B (zero-width space) は strip
- TradeEvent に island_name field
- aggregate / diff に ``--session`` / ``--island`` kwargs
- CLI trade {list,summary,diff} に同オプション
- events_to_csv/json に ``island_name`` 列

書記長の実セーブ (3,116 events) が 13 islands に綺麗に分布．大阪民国 657 件でトップ．

## Test plan

- [x] ``pytest --cov=anno_save_analyzer --cov-branch --cov-fail-under=100`` — 358 passed / 100%
- [x] ``ruff check`` / ``ruff format --check`` clean
- [x] Real save smoke: ``trade list sample_anno117.a8s --island 大阪民国`` returns 657 events
- [x] Interpreter zero-width-space strip verified on synthetic fixture
- [x] Backward compat: ``--island`` / ``--session`` 未指定時は従来挙動

## Out of scope (follow-ups)

- #30 Phase 2: TUI Statistics の Tree selection → items/routes/Partners/chart 連動
- Cursor review #1 (load_state decomposition) は Phase 2 で返済