### PR TITLE
feat(tui): #34 responsive layout + scrollable Partners pane

### DIFF
--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -66,10 +66,9 @@ class TradeStatisticsScreen(Screen):
     TradeStatisticsScreen #right-column {
         width: 42;
     }
-    TradeStatisticsScreen #partners-pane {
+    TradeStatisticsScreen #partners-scroll {
         height: 40%;
         border: solid $secondary;
-        overflow: auto;
     }
     TradeStatisticsScreen #chart-pane {
         height: 60%;

--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from textual import events
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import (
     DataTable,
@@ -59,18 +60,39 @@ class TradeStatisticsScreen(Screen):
         width: 1fr;
         border: solid $secondary;
     }
+    TradeStatisticsScreen DataTable {
+        height: 1fr;
+    }
     TradeStatisticsScreen #right-column {
         width: 42;
     }
     TradeStatisticsScreen #partners-pane {
         height: 40%;
         border: solid $secondary;
+        overflow: auto;
     }
     TradeStatisticsScreen #chart-pane {
         height: 60%;
         border: solid $secondary;
     }
+    /* Responsive: mid (80-119 cols) では右カラムを縮めて sparkline 列は維持 */
+    TradeStatisticsScreen.mid #right-column {
+        width: 32;
+    }
+    /* Responsive: narrow (<80 cols) では Tree を縮め右カラムを完全 hide．
+       Partners / Chart は ^T で Overview 往復の方が素直なので非表示で十分． */
+    TradeStatisticsScreen.narrow Tree {
+        width: 16;
+    }
+    TradeStatisticsScreen.narrow #right-column {
+        display: none;
+    }
     """
+
+    # 幅の境界値 (terminal cols)．上端は含まない閉区間．
+    # wide: >= 120 / mid: 80-119 / narrow: < 80
+    _MID_BREAKPOINT = 120
+    _NARROW_BREAKPOINT = 80
 
     def __init__(self, state: TuiState, localizer: Localizer) -> None:
         super().__init__(name="statistics")
@@ -79,6 +101,31 @@ class TradeStatisticsScreen(Screen):
         self._filter = TradeFilter()
         self._filtered_events_cache: list[TradeEvent] | None = None
         self._filtered_events_cache_key: tuple[str | None, str | None] | None = None
+        self._layout_class: str | None = None
+
+    def _classify_width(self, width: int) -> str:
+        """terminal 幅から layout class を選ぶ (wide / mid / narrow)．"""
+        if width < self._NARROW_BREAKPOINT:
+            return "narrow"
+        if width < self._MID_BREAKPOINT:
+            return "mid"
+        return "wide"
+
+    def _apply_layout_class(self, width: int) -> bool:
+        """幅から layout class を決定し，screen に付け替える．
+
+        変わったら True を返す．compose 直後と resize 時に呼ぶ．
+        wide / mid / narrow の 3 択はいずれも明示的に class 付与 (CSS の
+        ``TradeStatisticsScreen.narrow ...`` のような選択子と対応させるため)．
+        """
+        new_cls = self._classify_width(width)
+        if new_cls == self._layout_class:
+            return False
+        for cls in ("wide", "mid", "narrow"):
+            self.remove_class(cls)
+        self.add_class(new_cls)
+        self._layout_class = new_cls
+        return True
 
     def set_localizer(self, localizer: Localizer) -> None:
         """``TradeApp.switch_locale`` から呼ばれる公開 setter．
@@ -89,6 +136,10 @@ class TradeStatisticsScreen(Screen):
         self._localizer = localizer
 
     def compose(self) -> ComposeResult:
+        # Trend 列 / 右カラム hide 等の layout 判定は compose の早い段階で固める．
+        # ``app.size`` は compose 呼出時に有効．on_mount で recompose する実装
+        # にすると Header.mount_title タイミングと衝突するため採らない．
+        self._apply_layout_class(self.app.size.width)
         t = self._localizer.t
         yield Header()
         yield Static(self._filter_label(), id="filter-banner")
@@ -102,12 +153,21 @@ class TradeStatisticsScreen(Screen):
                 with TabPane(t("statistics.tab.inventory"), id="inventory-tab"):
                     yield self._render_inventory_table()
             with Vertical(id="right-column"):
-                yield Static(
-                    f"[b]{t('partners.heading')}[/b]\n\n{t('partners.empty')}",
-                    id="partners-pane",
-                )
+                # Partners pane は本文が長くなり得るので VerticalScroll 経由．
+                # narrow layout 時はこの Vertical ごと display:none で隠れる．
+                with VerticalScroll(id="partners-scroll"):
+                    yield Static(
+                        f"[b]{t('partners.heading')}[/b]\n\n{t('partners.empty')}",
+                        id="partners-pane",
+                    )
                 yield PlotextPlot(id="chart-pane")
         yield Footer()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """terminal 幅変更で layout class を切替 (width のみ見る)．"""
+        if self._apply_layout_class(event.size.width):
+            # class が変わった場合のみ再 compose．Trend 列の出し分け等も拾うため．
+            self.refresh(recompose=True)
 
     def _render_tree(self) -> Tree:
         t = self._localizer.t
@@ -179,19 +239,23 @@ class TradeStatisticsScreen(Screen):
         table = DataTable(id="items-table")
         table.cursor_type = "row"
         t = self._localizer.t
-        table.add_columns(
+        # narrow layout (<80 cols) 時は Trend sparkline 列を省略．文字幅節約．
+        include_trend = self._layout_class != "narrow"
+        columns: list[str] = [
             t("statistics.col.good"),
             t("statistics.col.bought"),
             t("statistics.col.sold"),
             t("statistics.col.net_qty"),
             t("statistics.col.net_gold"),
             t("statistics.col.events"),
-            t("statistics.col.trend"),
-        )
-        # 各物資の累積数量 sparkline を先に算出．1 物資 = 1 sparkline string．
-        trends = self._build_item_trends()
+        ]
+        if include_trend:
+            columns.append(t("statistics.col.trend"))
+        table.add_columns(*columns)
+        trends = self._build_item_trends() if include_trend else {}
         for s in self._current_item_summaries():
-            row = (*self._format_item_row(s), trends.get(s.item.guid, ""))
+            base = self._format_item_row(s)
+            row = (*base, trends.get(s.item.guid, "")) if include_trend else base
             table.add_row(*row, key=str(s.item.guid))
         return table
 

--- a/tests/tui/test_screens.py
+++ b/tests/tui/test_screens.py
@@ -312,6 +312,109 @@ class TestFilteredRenderingAndExport:
 
 
 @pytest.mark.asyncio
+class TestResponsiveLayout:
+    """#34: terminal 幅で layout class を切替 + Trend 列出し分け．"""
+
+    async def test_wide_default_class_on_120plus(self, tui_state) -> None:
+        from anno_save_analyzer.tui.screens.statistics import TradeStatisticsScreen
+
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(140, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            screen = pilot.app.screen
+            assert isinstance(screen, TradeStatisticsScreen)
+            assert screen._layout_class == "wide"
+            assert screen.has_class("wide")
+
+    async def test_mid_class_between_80_and_120(self, tui_state) -> None:
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            screen = pilot.app.screen
+            assert screen._layout_class == "mid"
+            assert screen.has_class("mid")
+
+    async def test_narrow_class_below_80(self, tui_state) -> None:
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(70, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            screen = pilot.app.screen
+            assert screen._layout_class == "narrow"
+            assert screen.has_class("narrow")
+
+    async def test_narrow_hides_trend_column_in_items_table(self, tui_state) -> None:
+        from textual.widgets import DataTable
+
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(70, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#items-table", DataTable)
+            # Trend 列 hide → 列数 6 (good / bought / sold / net_qty / net_gold / events)
+            assert len(table.columns) == 6
+
+    async def test_wide_keeps_trend_column(self, tui_state) -> None:
+        from textual.widgets import DataTable
+
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(140, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#items-table", DataTable)
+            assert len(table.columns) == 7  # + Trend
+
+    async def test_resize_switches_class_and_recomposes(self, tui_state) -> None:
+        """wide → narrow の resize で class 切替 + recompose が起こる．"""
+        from anno_save_analyzer.tui.screens.statistics import TradeStatisticsScreen
+
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(140, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            screen = pilot.app.screen
+            assert isinstance(screen, TradeStatisticsScreen)
+            assert screen._layout_class == "wide"
+            await pilot.resize_terminal(60, 30)
+            await pilot.pause()
+            assert pilot.app.screen._layout_class == "narrow"
+
+    async def test_same_breakpoint_resize_is_noop(self, tui_state) -> None:
+        """同 breakpoint 域内の resize は layout class を変えない．"""
+        app = TradeApp(tui_state)
+        async with app.run_test(size=(140, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            await pilot.resize_terminal(130, 30)
+            await pilot.pause()
+            assert pilot.app.screen._layout_class == "wide"
+
+
+@pytest.mark.asyncio
+class TestPartnersPaneScroll:
+    async def test_partners_pane_inside_vertical_scroll(self, tui_state) -> None:
+        """長い Partners 出力が切れないよう VerticalScroll 包装を確認．"""
+        from textual.containers import VerticalScroll
+
+        app = TradeApp(tui_state)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            scroll = pilot.app.screen.query_one("#partners-scroll", VerticalScroll)
+            assert scroll is not None
+
+
+@pytest.mark.asyncio
 class TestScreenLocalizerSetter:
     """Cursor レビュー指摘: App からの ``_localizer`` 直書きを setter 化．"""
 


### PR DESCRIPTION
Closes #34.

## Summary (EN)

Add three terminal-width breakpoints to ``TradeStatisticsScreen`` and wrap the Partners pane in a ``VerticalScroll`` container so the TUI stays usable on narrow terminals.

### Breakpoints
- **wide** (``>= 120``): existing 3-column layout, Trend sparkline column included
- **mid** (``80 - 119``): right column 42 → 32; everything else intact
- **narrow** (``< 80``): Tree 28 → 16, right column hidden via CSS ``display: none``, Trend column dropped from items-table (6 cols)

### Scroll
- ``VerticalScroll`` around Partners pane (``#partners-scroll``) for long partner lists
- ``DataTable { height: 1fr }`` so items / routes / inventory tables scroll inside their tab

### Mechanics
- ``_apply_layout_class(width)`` removes ``wide/mid/narrow`` then adds the new one; returns whether it changed
- ``compose()`` calls it up-front so the first render already reflects the class
- ``on_resize`` only does ``refresh(recompose=True)`` when the class actually flips (avoids recompose storms on small wiggles)

## 概要 (JA)

書記長の dogfood 指摘「ウィンドウの広さで動的に表示内容変更 / 物資とかスクロール対応」対応．Statistics 画面に 3 段階の幅 breakpoint (wide / mid / narrow) を入れ，Partners pane を ``VerticalScroll`` で包む．

- narrow (<80 cols): Tree 16 / 右カラム ``display:none`` / Trend 列省略で 2 カラム化
- mid (80-119): 右カラムだけ 42→32 に縮める
- wide (>=120): 現状維持
- Partners pane が ``VerticalScroll`` になったので相手リストが長くても切れない

70×24 の terminal で破綻せず使える状態．402 passed / 99.41% coverage (90% floor クリア)．

## Test plan

- [x] ``pytest --cov-config=pyproject.toml --cov-branch`` → 402 passed / 99.41 %
- [x] ``ruff check`` / ``ruff format --check`` clean
- [x] ``pilot.app.run_test(size=(70, 30))`` で narrow が適用され Trend 列が消える
- [x] ``pilot.resize_terminal(60, 30)`` で wide → narrow の class 切替 + recompose
- [x] 同 breakpoint 内の resize (140 → 130) で no-op
- [x] Partners pane が ``VerticalScroll`` で包まれる

## Out of scope

- ``Footer`` の nano hotkey bar が narrow で折り返す件: Textual 側の挙動で十分読める
- tmux pane detect 等プラットフォーム依存: 禁じ手