### PR TITLE
fix(tui): inventory chart x-axis uses relative time instead of sample index

### DIFF
--- a/src/anno_save_analyzer/trade/clock.py
+++ b/src/anno_save_analyzer/trade/clock.py
@@ -17,9 +17,10 @@ TICKS_PER_MINUTE = 600
 
 # ``StorageTrends > Points`` の 1 サンプル = 何 tick か．暫定値 = 1 分 (600)．
 # 公式ドキュメントは無く，Anno 内部の「在庫推移グラフ」の UI 観察とサンプル数
-# (capacity=120 固定) から 「120 samples = 2 hours」 と仮置きしている．書記長の
-# dogfood で違和感があれば調整する．clock モジュールに隔離して ad-hoc 値を
-# コード上からも見分けやすくする．
+# (capacity=120 固定) から「約 2 時間分の観測点」と仮置きしている．なお 1 分刻み
+# なら 120 サンプルの最古-最新の端点間スパンは 119 分．書記長の dogfood で
+# 違和感があれば調整する．clock モジュールに隔離して ad-hoc 値をコード上からも
+# 見分けやすくする．
 SAMPLE_INTERVAL_TICKS = TICKS_PER_MINUTE  # 1 sample = 1 minute 仮定
 
 
@@ -46,8 +47,9 @@ def inventory_sample_minutes(
 ) -> list[float]:
     """StorageTrends の N サンプルを「何分前」相対値に展開．
 
-    最新サンプル (``samples[-1]``) を 0，最古を ``-(n-1) * step / ticks_per_min``
-    として左に並べる．chart の x 軸は昇順なので最古が左端．
+    最新サンプル (``samples[-1]``) を 0，最古を
+    ``-(n_samples - 1) * step_ticks / TICKS_PER_MINUTE`` として左に並べる．
+    chart の x 軸は昇順なので最古が左端．
     """
     return [(i - (n_samples - 1)) * step_ticks / TICKS_PER_MINUTE for i in range(n_samples)]
 

--- a/src/anno_save_analyzer/trade/clock.py
+++ b/src/anno_save_analyzer/trade/clock.py
@@ -15,6 +15,13 @@ from collections.abc import Iterable
 # 差分分布から検証した値．Anno 1800 も同等と仮定 (要検証)．
 TICKS_PER_MINUTE = 600
 
+# ``StorageTrends > Points`` の 1 サンプル = 何 tick か．暫定値 = 1 分 (600)．
+# 公式ドキュメントは無く，Anno 内部の「在庫推移グラフ」の UI 観察とサンプル数
+# (capacity=120 固定) から 「120 samples = 2 hours」 と仮置きしている．書記長の
+# dogfood で違和感があれば調整する．clock モジュールに隔離して ad-hoc 値を
+# コード上からも見分けやすくする．
+SAMPLE_INTERVAL_TICKS = TICKS_PER_MINUTE  # 1 sample = 1 minute 仮定
+
 
 def minutes_relative_to(tick: int, *, now_tick: int) -> float:
     """``tick`` を ``now_tick`` からの相対分数 (負=過去) として返す．
@@ -32,6 +39,17 @@ def latest_tick(ticks: Iterable[int]) -> int | None:
 
 # spread がこの分数を超えたら時間単位に切り替える閾値．
 _HOURS_UNIT_THRESHOLD_MIN = 120.0
+
+
+def inventory_sample_minutes(
+    n_samples: int, step_ticks: int = SAMPLE_INTERVAL_TICKS
+) -> list[float]:
+    """StorageTrends の N サンプルを「何分前」相対値に展開．
+
+    最新サンプル (``samples[-1]``) を 0，最古を ``-(n-1) * step / ticks_per_min``
+    として左に並べる．chart の x 軸は昇順なので最古が左端．
+    """
+    return [(i - (n_samples - 1)) * step_ticks / TICKS_PER_MINUTE for i in range(n_samples)]
 
 
 def pick_time_unit(values_minutes: Iterable[float]) -> tuple[str, float]:

--- a/src/anno_save_analyzer/tui/locales/en.yaml
+++ b/src/anno_save_analyzer/tui/locales/en.yaml
@@ -58,7 +58,6 @@ statistics.chart.xlabel.minutes_ago: "minutes (0 = latest)"
 statistics.chart.xlabel.hours_ago: "hours (0 = latest)"
 statistics.chart.idle_suffix: "{status}, {legs} legs"
 statistics.chart.no_inventory_samples: "{title} — no inventory samples"
-statistics.chart.sample_index: "sample index"
 
 partners.heading: "Partners"
 partners.empty: "Pick a good in the table to see partners."

--- a/src/anno_save_analyzer/tui/locales/ja.yaml
+++ b/src/anno_save_analyzer/tui/locales/ja.yaml
@@ -58,7 +58,6 @@ statistics.chart.xlabel.minutes_ago: "分 (0=最新)"
 statistics.chart.xlabel.hours_ago: "時間 (0=最新)"
 statistics.chart.idle_suffix: "{status}, {legs} レグ"
 statistics.chart.no_inventory_samples: "{title} — 在庫サンプルなし"
-statistics.chart.sample_index: "サンプル番号"
 
 partners.heading: "取引相手"
 partners.empty: "テーブルから物資を選ぶと相手リストを表示．"

--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -534,19 +534,27 @@ class TradeStatisticsScreen(Screen):
         )
         if trend is None:
             return
+        from anno_save_analyzer.trade.clock import (
+            inventory_sample_minutes,
+            pick_time_unit,
+        )
+
         item = self._state.items[guid]
         title = f"{island} · {item.display_name(self._localizer.code)}"
         samples = list(trend.points.samples)
         if not samples:
             self._render_empty_chart(t("statistics.chart.no_inventory_samples", title=title))
             return
-        x_values = list(range(len(samples)))
+        # 最新 = 0，最古 = -(n-1) * step．chart は昇順なので左端が最古．
+        minutes = inventory_sample_minutes(len(samples))
+        unit_key, divisor = pick_time_unit(minutes)
+        x_values = [m * divisor for m in minutes]
         chart = self.query_one("#chart-pane", PlotextPlot)
         chart.plt.clear_data()
         chart.plt.clear_figure()
         chart.plt.plot(x_values, samples, marker="hd")
         chart.plt.title(title)
-        chart.plt.xlabel(t("statistics.chart.sample_index"))
+        chart.plt.xlabel(t(f"statistics.chart.xlabel.{unit_key}"))
         chart.plt.ylabel(t("statistics.col.latest"))
         chart.refresh()
 

--- a/tests/trade/test_clock.py
+++ b/tests/trade/test_clock.py
@@ -57,3 +57,43 @@ class TestPickTimeUnit:
         unit, div = pick_time_unit([-500.0, 0.0])
         assert unit == "hours_ago"
         assert div == pytest.approx(1.0 / 60.0)
+
+
+class TestInventorySampleMinutes:
+    def test_latest_sample_at_zero(self) -> None:
+        from anno_save_analyzer.trade.clock import inventory_sample_minutes
+
+        out = inventory_sample_minutes(5)
+        assert out[-1] == 0.0
+        # 最古サンプルは -(5-1)*1 = -4 分 (step=600 tick = 1 min default)
+        assert out[0] == -4.0
+        # 昇順
+        assert out == sorted(out)
+
+    def test_single_sample_is_zero(self) -> None:
+        from anno_save_analyzer.trade.clock import inventory_sample_minutes
+
+        assert inventory_sample_minutes(1) == [0.0]
+
+    def test_empty_returns_empty(self) -> None:
+        from anno_save_analyzer.trade.clock import inventory_sample_minutes
+
+        assert inventory_sample_minutes(0) == []
+
+    def test_120_samples_span_two_hours(self) -> None:
+        """書記長の dogfood 仮定: capacity=120 で 2 時間分の履歴 (step=600 ticks=1 分)．"""
+        from anno_save_analyzer.trade.clock import inventory_sample_minutes
+
+        out = inventory_sample_minutes(120)
+        assert out[-1] == 0.0
+        assert out[0] == -119.0
+        # 最古から最新までの spread = 119 分 (≈ 2 時間)
+        assert out[-1] - out[0] == 119.0
+
+    def test_custom_step_ticks(self) -> None:
+        """step を ticks_per_minute=600 / 10 = 60 (= 0.1 分) にすると細かくなる．"""
+        from anno_save_analyzer.trade.clock import inventory_sample_minutes
+
+        out = inventory_sample_minutes(5, step_ticks=60)
+        # 60 tick = 0.1 分
+        assert out == pytest.approx([-0.4, -0.3, -0.2, -0.1, 0.0])

--- a/tests/tui/test_screens.py
+++ b/tests/tui/test_screens.py
@@ -923,7 +923,8 @@ class TestStatisticsScreen:
             inv_table = screen.query_one("#inventory-table", DataTable)
             screen.on_data_table_row_highlighted(_Evt(inv_table, ("A|B", 100)))
             await pilot.pause()
-            assert xlabel_calls[-1] == "サンプル番号"
+            # 3 サンプル = spread 2 分なので minutes_ago 単位．ja ロケール．
+            assert xlabel_calls[-1] == "分 (0=最新)"
 
     async def test_inventory_empty_samples_uses_inventory_message(self, tui_state) -> None:
         from anno_save_analyzer.trade import IslandStorageTrend, PointSeries


### PR DESCRIPTION
## Summary (EN)

書記長 dogfood feedback after v0.4.0: **\"sample numbers aren't readable, I want a timeline\"**.

Previously the chart rendered on Inventory tab row highlight used a bare 0-119 sample index for the x-axis. This PR converts the x-axis to relative minutes / hours (latest sample = 0, going negative into the past) by way of a new ``inventory_sample_minutes`` helper in ``trade.clock`` plus the existing ``pick_time_unit`` auto-switch logic (minutes for small spreads, hours for big ones).

No official doc on ``Points`` sample cadence exists, so ``SAMPLE_INTERVAL_TICKS = 600`` (= 1 sample = 1 minute) is used as a provisional value. Under that assumption the default 120-sample ring buffer spans 2 hours. Easy to tweak in one place if real-save observation disagrees.

## 概要 (JA)

v0.4.0 後の書記長 dogfood 指摘「**サンプル番号じゃわからないやん！時系列が欲しいの！**」に対応．

Inventory タブの行 highlight 時に描画する chart の横軸を ``0-119`` のサンプル番号から相対時間 (最新を 0 とした分前 / 時間前) に切替．``trade.clock`` に ``SAMPLE_INTERVAL_TICKS`` 定数と ``inventory_sample_minutes`` ヘルパーを追加し，spread に応じて既存の ``pick_time_unit`` が分 / 時間を auto 切替する仕組みに乗せた．

``Points`` の 1 サンプル tick 数は公式資料が無いため暫定 600 (= 1 分) と置いた．120 samples = 2 時間の履歴という前提．書記長の観察で違和感があれば ``trade/clock.py`` の定数 1 行で調整可能．

## Test plan

- [x] ``pytest --cov-config=pyproject.toml --cov-branch`` → 407 passed / 99.41 %
- [x] ``ruff check`` / ``ruff format --check`` clean
- [x] Real save smoke: ``anno-save-analyzer tui sample_anno117.a8s`` → Inventory タブで行選択すると ``minutes (0 = latest)`` / ``分 (0=最新)`` ラベルの横軸が出る
- [x] Locale 切替 (``^L``) 時も xlabel がローカライズされる