### PR TITLE
feat(trade): show custom route names in routes-table and Partners pane

### DIFF
--- a/src/anno_save_analyzer/trade/aggregate.py
+++ b/src/anno_save_analyzer/trade/aggregate.py
@@ -58,8 +58,21 @@ class RouteSummary(BaseModel):
     net_gold: int = 0
     event_count: int = 0
     last_seen_tick: int | None = None
+    route_name: str | None = None
+    """書記長命名のルート名．``partner_kind='route'`` のみ．表示では
+    ``route_name`` 優先，無ければ ``route_id`` を fallback．
+    """
 
     model_config = {"frozen": True}
+
+    @property
+    def display_route(self) -> str:
+        """routes-table 向け表示ラベル．route_name > ``#{route_id}`` > ``—``．"""
+        if self.route_name:
+            return self.route_name
+        if self.route_id is not None:
+            return f"#{self.route_id}"
+        return "—"
 
 
 class PartnerSummary(BaseModel):
@@ -73,6 +86,7 @@ class PartnerSummary(BaseModel):
     sold: int = 0
     net_gold: int = 0
     event_count: int = 0
+    route_name: str | None = None
 
     model_config = {"frozen": True}
 
@@ -81,7 +95,9 @@ class PartnerSummary(BaseModel):
 
     @property
     def display_partner(self) -> str:
-        """partner pane で表示する相手ラベル．route 優先，無ければ partner_id．"""
+        """partner pane で表示する相手ラベル．route_name > route_id > partner_id．"""
+        if self.route_name:
+            return f"route {self.route_name}"
         if self.route_id is not None:
             return f"route #{self.route_id}"
         if self.partner_id is not None:
@@ -153,6 +169,7 @@ def by_route(
             "net_gold": 0,
             "event_count": 0,
             "last_seen_tick": None,
+            "route_name": None,
         }
     )
     for ev in events:
@@ -169,6 +186,10 @@ def by_route(
             current = bucket["last_seen_tick"]
             if current is None or ev.timestamp_tick > current:
                 bucket["last_seen_tick"] = ev.timestamp_tick
+        # route_name は同一 route_id 内で変わる可能性 (書記長が途中で rename)．
+        # last_seen_tick が進むタイミングで上書き．tick 不明なら first-seen 優先．
+        if ev.route_name and (bucket["route_name"] is None or ev.timestamp_tick is not None):
+            bucket["route_name"] = ev.route_name
 
     summaries = [
         RouteSummary(route_id=route_id, partner_kind=kind, **bucket)
@@ -199,6 +220,7 @@ def partners_for_item(
             "sold": 0,
             "net_gold": 0,
             "event_count": 0,
+            "route_name": None,
         }
     )
     item: Item | None = None
@@ -216,6 +238,8 @@ def partners_for_item(
             bucket["sold"] += -ev.amount
         bucket["net_gold"] += ev.total_price
         bucket["event_count"] += 1
+        if ev.route_name and bucket["route_name"] is None:
+            bucket["route_name"] = ev.route_name
 
     if item is None:
         return []

--- a/src/anno_save_analyzer/trade/aggregate.py
+++ b/src/anno_save_analyzer/trade/aggregate.py
@@ -172,6 +172,7 @@ def by_route(
             "route_name": None,
         }
     )
+    route_name_last_seen_tick: dict[tuple[str | None, str], int | None] = {}
     for ev in events:
         kind = ev.partner.kind if ev.partner else "unknown"
         key = (ev.route_id, kind)
@@ -187,9 +188,16 @@ def by_route(
             if current is None or ev.timestamp_tick > current:
                 bucket["last_seen_tick"] = ev.timestamp_tick
         # route_name は同一 route_id 内で変わる可能性 (書記長が途中で rename)．
-        # last_seen_tick が進むタイミングで上書き．tick 不明なら first-seen 優先．
-        if ev.route_name and (bucket["route_name"] is None or ev.timestamp_tick is not None):
-            bucket["route_name"] = ev.route_name
+        # route_name 用の最新 tick を別管理し，入力順に依存せず最新 rename を採用する．
+        if ev.route_name:
+            route_name_tick = ev.timestamp_tick
+            current_name_tick = route_name_last_seen_tick.get(key)
+            if route_name_tick is None:
+                if bucket["route_name"] is None:
+                    bucket["route_name"] = ev.route_name
+            elif current_name_tick is None or route_name_tick > current_name_tick:
+                bucket["route_name"] = ev.route_name
+                route_name_last_seen_tick[key] = route_name_tick
 
     summaries = [
         RouteSummary(route_id=route_id, partner_kind=kind, **bucket)

--- a/src/anno_save_analyzer/trade/aggregate.py
+++ b/src/anno_save_analyzer/trade/aggregate.py
@@ -192,8 +192,9 @@ def by_route(
         if ev.route_name:
             route_name_tick = ev.timestamp_tick
             current_name_tick = route_name_latest_tick_by_key.get(key)
-            if route_name_tick is None and bucket["route_name"] is None:
-                bucket["route_name"] = ev.route_name
+            if route_name_tick is None:
+                if bucket["route_name"] is None:
+                    bucket["route_name"] = ev.route_name
             elif current_name_tick is None or route_name_tick > current_name_tick:
                 bucket["route_name"] = ev.route_name
                 route_name_latest_tick_by_key[key] = route_name_tick

--- a/src/anno_save_analyzer/trade/aggregate.py
+++ b/src/anno_save_analyzer/trade/aggregate.py
@@ -172,7 +172,7 @@ def by_route(
             "route_name": None,
         }
     )
-    route_name_last_seen_tick: dict[tuple[str | None, str], int | None] = {}
+    route_name_latest_tick_by_key: dict[tuple[str | None, str], int | None] = {}
     for ev in events:
         kind = ev.partner.kind if ev.partner else "unknown"
         key = (ev.route_id, kind)
@@ -191,13 +191,12 @@ def by_route(
         # route_name 用の最新 tick を別管理し，入力順に依存せず最新 rename を採用する．
         if ev.route_name:
             route_name_tick = ev.timestamp_tick
-            current_name_tick = route_name_last_seen_tick.get(key)
-            if route_name_tick is None:
-                if bucket["route_name"] is None:
-                    bucket["route_name"] = ev.route_name
+            current_name_tick = route_name_latest_tick_by_key.get(key)
+            if route_name_tick is None and bucket["route_name"] is None:
+                bucket["route_name"] = ev.route_name
             elif current_name_tick is None or route_name_tick > current_name_tick:
                 bucket["route_name"] = ev.route_name
-                route_name_last_seen_tick[key] = route_name_tick
+                route_name_latest_tick_by_key[key] = route_name_tick
 
     summaries = [
         RouteSummary(route_id=route_id, partner_kind=kind, **bucket)

--- a/src/anno_save_analyzer/trade/exports.py
+++ b/src/anno_save_analyzer/trade/exports.py
@@ -57,7 +57,8 @@ def routes_to_csv(
 ) -> str:
     """ルート別サマリ + idle route 定義を CSV にエクスポート．
 
-    列: route_id, status, partner_kind, legs, bought, sold, net_gold, event_count
+    列: route_id, route_name, status, partner_kind, legs, bought, sold,
+         net_gold, event_count
     """
     active = set(active_ids)
     legs_by_ship: dict[str, int] = {}
@@ -67,7 +68,17 @@ def routes_to_csv(
             legs_by_ship[str(rd.ship_id)] = len(rd.tasks)
 
     rows: list[list[str]] = [
-        ["route_id", "status", "partner_kind", "legs", "bought", "sold", "net_gold", "event_count"]
+        [
+            "route_id",
+            "route_name",
+            "status",
+            "partner_kind",
+            "legs",
+            "bought",
+            "sold",
+            "net_gold",
+            "event_count",
+        ]
     ]
     seen: set[str] = set()
     for s in summaries:
@@ -76,6 +87,7 @@ def routes_to_csv(
         rows.append(
             [
                 rid,
+                s.route_name or "",
                 "active",
                 s.partner_kind,
                 str(legs),
@@ -88,13 +100,14 @@ def routes_to_csv(
         if rid:
             seen.add(rid)
     # idle = 定義あり / 履歴無し．active_ids に含まれないもののみ出す．
+    # idle 側は route_name を持たない (定義側の attrib は未読)．空文字で出力．
     for rd in idle_list:
         if rd.ship_id is None:
             continue
         rid = str(rd.ship_id)
         if rid in active or rid in seen:
             continue
-        rows.append([rid, "idle", "route", str(len(rd.tasks)), "0", "0", "0", "0"])
+        rows.append([rid, "", "idle", "route", str(len(rd.tasks)), "0", "0", "0", "0"])
         seen.add(rid)
     return _csv_writer(rows)
 
@@ -102,8 +115,8 @@ def routes_to_csv(
 def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str:
     """個別 TradeEvent を CSV にエクスポート (ledger 全量)．
 
-    列: timestamp_tick, session_id, island_name, route_id, partner_id,
-         partner_kind, item_guid, item_name, amount, total_price
+    列: timestamp_tick, session_id, island_name, route_id, route_name,
+         partner_id, partner_kind, item_guid, item_name, amount, total_price
     """
     rows: list[list[str]] = [
         [
@@ -111,6 +124,7 @@ def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str
             "session_id",
             "island_name",
             "route_id",
+            "route_name",
             "partner_id",
             "partner_kind",
             "item_guid",
@@ -128,6 +142,7 @@ def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str
                 ev.session_id or "",
                 ev.island_name or "",
                 ev.route_id or "",
+                ev.route_name or "",
                 partner_id,
                 partner_kind,
                 str(ev.item.guid),
@@ -191,6 +206,7 @@ def events_to_json(events: Iterable[TradeEvent], *, locale: Locale = "en") -> st
                 "session_id": ev.session_id,
                 "island_name": ev.island_name,
                 "route_id": ev.route_id,
+                "route_name": ev.route_name,
                 "partner": ({"id": ev.partner.id, "kind": ev.partner.kind} if ev.partner else None),
                 "item": {
                     "guid": ev.item.guid,

--- a/src/anno_save_analyzer/trade/extract.py
+++ b/src/anno_save_analyzer/trade/extract.py
@@ -51,6 +51,7 @@ def normalise(
         route_id=raw.context.route_id,
         session_id=raw.context.session_id,
         island_name=raw.context.island_name,
+        route_name=raw.context.route_name,
         source_method="history",
     )
 

--- a/src/anno_save_analyzer/trade/interpreter/anno117.py
+++ b/src/anno_save_analyzer/trade/interpreter/anno117.py
@@ -42,6 +42,7 @@ _CITY_NAME_ATTRIB = "CityName"
 # - PassiveTradeEntries 配下 → partner_id（NPC trader の GUID）
 _TRADER_ATTRIB = "Trader"
 _ROUTE_ID_ATTRIB = "RouteID"
+_ROUTE_NAME_ATTRIB = "RouteName"
 _TIMESTAMP_ATTRIB_CANDIDATES = (
     # Anno 117 実測: 内側 <1> の ``ExecutionTime`` (i64 tick) が個別取引の時刻．
     # 1,533 entries 全件に 8B で入ってる．他の候補は 1800 や別パッチ用の保険．
@@ -266,11 +267,13 @@ def _build_triple_if_complete(
     timestamp_tick = _first_int_attrib(ancestor_attribs, _TIMESTAMP_ATTRIB_CANDIDATES)
 
     route_id: str | None = None
+    route_name: str | None = None
     partner_id: str | None = None
     if kind == "route":
         route_value = _first_int32_attrib(ancestor_attribs, (_ROUTE_ID_ATTRIB,))
         if route_value is not None:
             route_id = str(route_value)
+        route_name = _first_utf16_attrib(ancestor_attribs, (_ROUTE_NAME_ATTRIB,))
     elif kind == "passive":
         partner_value = _first_int32_attrib(ancestor_attribs, (_TRADER_ATTRIB,))
         if partner_value is not None:
@@ -287,6 +290,7 @@ def _build_triple_if_complete(
             partner_kind=kind,
             timestamp_tick=timestamp_tick,
             island_name=island_name,
+            route_name=route_name,
         ),
     )
 
@@ -314,6 +318,28 @@ def _first_int_attrib(
                     return _read_int64(value)
                 if len(value) == 4:
                     return _read_int32(value)
+    return None
+
+
+def _first_utf16_attrib(
+    attrib_stack: list[dict[str, bytes]], candidates: tuple[str, ...]
+) -> str | None:
+    """ancestor から UTF-16-LE attrib を拾って文字列に復号．
+
+    空文字や U+200B のみは ``None`` 扱い．``CityName`` で観測した ZWSP の混入と
+    同じ処理をして表示に耐える形にする．``RouteName`` 等で使う．
+    """
+    for attribs in reversed(attrib_stack):
+        for candidate in candidates:
+            if candidate in attribs:
+                raw = attribs[candidate]
+                decoded = (
+                    raw.decode("utf-16-le", errors="replace")
+                    .rstrip("\x00")
+                    .replace("\u200b", "")
+                    .strip()
+                )
+                return decoded or None
     return None
 
 

--- a/src/anno_save_analyzer/trade/interpreter/base.py
+++ b/src/anno_save_analyzer/trade/interpreter/base.py
@@ -32,6 +32,11 @@ class ExtractionContext:
     attach する．Anno 117 で実測．Anno 1800 でも同構造なら取れるはず (v0.3.1 は
     117 のみ対象)．
     """
+    route_name: str | None = None
+    """書記長がゲーム内で命名したトレードルート名．``TradeRouteEntries > <1> >
+    <1>`` inner entry の ``RouteName`` attrib (UTF-16LE) から抽出．``partner_kind``
+    が ``"route"`` のときのみ意味を持つ．CityName と同じく U+200B strip．
+    """
 
 
 @dataclass(frozen=True)

--- a/src/anno_save_analyzer/trade/models.py
+++ b/src/anno_save_analyzer/trade/models.py
@@ -75,6 +75,11 @@ class TradeEvent(BaseModel):
     interpreter 側で除外済みのためここに載るのは全てプレイヤー所有．
     TUI 側の Tree filter (島単位 / セッション単位) の key．
     """
+    route_name: str | None = None
+    """書記長がゲーム内で命名したトレードルート名．``partner_kind='route'`` の
+    ときのみ意味を持つ．表示では ``route_name`` 優先，無ければ ``route_id`` を
+    fallback．
+    """
     source_method: SourceMethod = "history"
 
     model_config = {"frozen": True}

--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -394,10 +394,9 @@ class TradeStatisticsScreen(Screen):
 
     def _format_route_row(self, s: RouteSummary, legs: int, *, active: bool) -> tuple[str, ...]:
         t = self._localizer.t
-        route_id = s.route_id if s.route_id is not None else "—"
         status = t("statistics.status.active") if active else t("statistics.status.idle")
         return (
-            route_id,
+            s.display_route,  # route_name 優先．無ければ #<route_id> or "—"
             status,
             s.partner_kind,
             f"{legs:,}",
@@ -410,7 +409,7 @@ class TradeStatisticsScreen(Screen):
     def _format_idle_route_row(self, rd) -> tuple[str, ...]:
         t = self._localizer.t
         return (
-            str(rd.ship_id),
+            f"#{rd.ship_id}",
             t("statistics.status.idle"),
             "route",
             f"{len(rd.tasks):,}",

--- a/tests/trade/conftest.py
+++ b/tests/trade/conftest.py
@@ -28,6 +28,7 @@ def make_inner_filedb(
     triples_by_kind: dict[Literal["route", "passive"], list[tuple[int, int, int, int]]],
     *,
     include_npc_island: bool = False,
+    route_names: dict[int, str] | None = None,
 ) -> bytes:
     """内側 FileDB V3 を組み立てる．
 
@@ -58,7 +59,9 @@ def make_inner_filedb(
         0x8004: "TotalPrice",
         0x8005: "CityName",
         0x8006: "RouteID",
+        0x8007: "RouteName",
     }
+    route_names = route_names or {}
 
     def _trade_subtree() -> list[Event]:
         sub: list[Event] = []
@@ -79,6 +82,9 @@ def make_inner_filedb(
                     # 実セーブの inner entry 構造に合わせる (interpreter の文脈分岐で必要)．
                     ident_attrib = 0x8006 if kind == "route" else 0x8001
                     sub.append(("A", ident_attrib, struct.pack("<i", trader_)))
+                    # route に限り RouteName (UTF-16-LE) も添付可能．書記長命名ルート．
+                    if kind == "route" and trader_ in route_names:
+                        sub.append(("A", 0x8007, route_names[trader_].encode("utf-16-le")))
                     sub.append(("T", 6))  # TradedGoods
                     sub.append(("T", 1))  # depth=1 wrapper
                     sub.append(("A", 0x8002, struct.pack("<i", good)))

--- a/tests/trade/test_aggregate.py
+++ b/tests/trade/test_aggregate.py
@@ -150,6 +150,14 @@ class TestByRoute:
         assert rows[0].route_name == "新ルート"
         assert rows[0].display_route == "新ルート"
 
+    def test_route_name_latest_tick_wins_even_if_events_are_out_of_order(self) -> None:
+        events = [
+            _ev(1, 1, 1, route_id="7", kind="route", timestamp=200, route_name="新ルート"),
+            _ev(1, 1, 1, route_id="7", kind="route", timestamp=100, route_name="旧ルート"),
+        ]
+        rows = by_route(events)
+        assert rows[0].route_name == "新ルート"
+
     def test_display_route_fallback_chain(self) -> None:
         """route_name > ``#{route_id}`` > ``—``."""
         events = [

--- a/tests/trade/test_aggregate.py
+++ b/tests/trade/test_aggregate.py
@@ -158,6 +158,14 @@ class TestByRoute:
         rows = by_route(events)
         assert rows[0].route_name == "新ルート"
 
+    def test_route_name_with_no_tick_does_not_override_ticked_name(self) -> None:
+        events = [
+            _ev(1, 1, 1, route_id="7", kind="route", timestamp=200, route_name="新ルート"),
+            _ev(1, 1, 1, route_id="7", kind="route", timestamp=None, route_name="旧ルート"),
+        ]
+        rows = by_route(events)
+        assert rows[0].route_name == "新ルート"
+
     def test_display_route_fallback_chain(self) -> None:
         """route_name > ``#{route_id}`` > ``—``."""
         events = [

--- a/tests/trade/test_aggregate.py
+++ b/tests/trade/test_aggregate.py
@@ -22,6 +22,7 @@ def _ev(
     partner: TradingPartner | None | object = ...,
     session_id: str | None = None,
     island_name: str | None = None,
+    route_name: str | None = None,
 ) -> TradeEvent:
     item = Item(guid=guid, names={"en": f"Good_{guid}"})
     # partner = sentinel (...) なら kind と route_id から自動生成．
@@ -37,6 +38,7 @@ def _ev(
         timestamp_tick=timestamp,
         session_id=session_id,
         island_name=island_name,
+        route_name=route_name,
     )
 
 
@@ -138,6 +140,27 @@ class TestByRoute:
         assert rows[0].route_id == "r2"
         assert rows[1].route_id == "r1"
 
+    def test_route_name_aggregates_with_latest_tick_winning(self) -> None:
+        """同一 route_id 内で途中 rename された場合，tick が進むタイミングで上書き．"""
+        events = [
+            _ev(1, 1, 1, route_id="7", kind="route", timestamp=100, route_name="旧ルート"),
+            _ev(1, 1, 1, route_id="7", kind="route", timestamp=200, route_name="新ルート"),
+        ]
+        rows = by_route(events)
+        assert rows[0].route_name == "新ルート"
+        assert rows[0].display_route == "新ルート"
+
+    def test_display_route_fallback_chain(self) -> None:
+        """route_name > ``#{route_id}`` > ``—``."""
+        events = [
+            _ev(1, 1, 1, route_id="42", kind="route"),
+            _ev(2, 1, 1, route_id=None, kind="unknown", partner=None),
+        ]
+        rows = by_route(events)
+        labels = {r.display_route for r in rows}
+        assert "#42" in labels
+        assert "—" in labels
+
 
 class TestPartnersForItem:
     def test_groups_by_route_and_partner_kind(self) -> None:
@@ -197,6 +220,13 @@ class TestPartnersForItem:
         assert "route #42" in labels
         assert "partner #99" in labels
         assert "—" in labels
+
+    def test_display_partner_uses_route_name_when_present(self) -> None:
+        """route_name があれば ``route <name>`` を優先．"""
+        events = [_ev(100, 1, 10, route_id="42", kind="route", route_name="商会ルート")]
+        rows = partners_for_item(events, 100)
+        assert rows[0].route_name == "商会ルート"
+        assert rows[0].display_partner == "route 商会ルート"
 
     def test_display_name_helper(self) -> None:
         events = [_ev(100, 1, 10, route_id="r")]

--- a/tests/trade/test_exports.py
+++ b/tests/trade/test_exports.py
@@ -122,15 +122,25 @@ class TestRoutesToCsv:
         ]
         out = routes_to_csv(summaries, idle_routes=idle, active_ids=("7",))
         rows = list(csv.reader(io.StringIO(out)))
-        assert rows[0][:4] == ["route_id", "status", "partner_kind", "legs"]
+        assert rows[0] == [
+            "route_id",
+            "route_name",
+            "status",
+            "partner_kind",
+            "legs",
+            "bought",
+            "sold",
+            "net_gold",
+            "event_count",
+        ]
         # active row (route_id=7) の legs は idle_routes 由来で 1
         active_row = next(r for r in rows[1:] if r[0] == "7")
-        assert active_row[1] == "active"
-        assert active_row[3] == "1"
+        assert active_row[2] == "active"
+        assert active_row[4] == "1"
         # idle row (ship=99) は status=idle
         idle_row = next(r for r in rows[1:] if r[0] == "99")
-        assert idle_row[1] == "idle"
-        assert idle_row[3] == "2"
+        assert idle_row[2] == "idle"
+        assert idle_row[4] == "2"
 
     def test_idle_routes_with_none_ship_id_skipped(self) -> None:
         idle = [
@@ -152,8 +162,27 @@ class TestRoutesToCsv:
         out = routes_to_csv(summaries)
         rows = list(csv.reader(io.StringIO(out)))
         assert len(rows) == 2
-        assert rows[1][0] == ""
-        assert rows[1][1] == "active"
+        assert rows[1][0] == ""  # route_id
+        assert rows[1][1] == ""  # route_name
+        assert rows[1][2] == "active"
+
+    def test_active_summary_with_route_name_emits_name_column(self) -> None:
+        """RouteSummary.route_name が route_name 列に流れ込む．"""
+        summaries = [
+            RouteSummary(
+                route_id="7",
+                partner_kind="route",
+                bought=10,
+                sold=0,
+                net_gold=100,
+                event_count=3,
+                route_name="商会ルート",
+            )
+        ]
+        out = routes_to_csv(summaries)
+        rows = list(csv.reader(io.StringIO(out)))
+        assert rows[1][0] == "7"
+        assert rows[1][1] == "商会ルート"
 
     def test_idle_route_already_in_active_ids_is_skipped(self) -> None:
         """active_ids に含まれる ship_id は idle として重複出力しない．"""
@@ -189,19 +218,17 @@ class TestEventsToCsvAndJson:
 
     def test_events_csv_has_all_columns(self) -> None:
         events = [
-            self._ev(route_id="7", session_id="0", timestamp_tick=100),
+            self._ev(route_id="7", session_id="0", timestamp_tick=100, route_name="商会ルート"),
             self._ev(guid=200, amount=-2, price=-50, partner=None, session_id=None),
         ]
         out = events_to_csv(events)
         rows = list(csv.reader(io.StringIO(out)))
-        # column order: timestamp_tick, session_id, island_name, route_id,
-        #               partner_id, partner_kind, item_guid, item_name,
-        #               amount, total_price
         assert rows[0] == [
             "timestamp_tick",
             "session_id",
             "island_name",
             "route_id",
+            "route_name",
             "partner_id",
             "partner_kind",
             "item_guid",
@@ -210,10 +237,12 @@ class TestEventsToCsvAndJson:
             "total_price",
         ]
         assert rows[1][0] == "100"  # timestamp
-        assert rows[1][6] == "100"  # item_guid
+        assert rows[1][4] == "商会ルート"  # route_name
+        assert rows[1][7] == "100"  # item_guid
         # 2 行目 partner=None
-        assert rows[2][4] == ""  # partner_id
-        assert rows[2][5] == ""  # partner_kind
+        assert rows[2][4] == ""  # route_name
+        assert rows[2][5] == ""  # partner_id
+        assert rows[2][6] == ""  # partner_kind
         # timestamp 無し
         assert rows[2][0] == ""
 

--- a/tests/trade/test_interpreter_anno117.py
+++ b/tests/trade/test_interpreter_anno117.py
@@ -95,6 +95,47 @@ class TestAnno117ExtractionFromSyntheticDOM:
         triples = list(Anno117Interpreter().find_traded_goods(outer, section))
         assert len(triples) == 1
 
+    def test_route_name_extracted_from_inner_entry(self) -> None:
+        """RouteName attrib が inner <1> に付いていれば ExtractionContext に流れる．"""
+        inner = make_inner_filedb(
+            {"route": [(41, 2088, 5, 0)]},
+            route_names={41: "商会ルート"},
+        )
+        outer = wrap_as_outer([inner])
+        section = parse_tag_section(outer, detect_version(outer))
+        triples = list(Anno117Interpreter().find_traded_goods(outer, section))
+        assert len(triples) == 1
+        assert triples[0].context.route_name == "商会ルート"
+
+    def test_route_name_zwsp_stripped(self) -> None:
+        """U+200B 混入は strip (CityName 同様の実測挙動)．"""
+        inner = make_inner_filedb(
+            {"route": [(42, 2088, 1, 0)]},
+            route_names={42: "\u200b商会ルート\u200b"},
+        )
+        outer = wrap_as_outer([inner])
+        section = parse_tag_section(outer, detect_version(outer))
+        triples = list(Anno117Interpreter().find_traded_goods(outer, section))
+        assert triples[0].context.route_name == "商会ルート"
+
+    def test_route_name_absent_leaves_none(self) -> None:
+        """RouteName が無い route の場合 ``route_name`` は ``None``．"""
+        inner = make_inner_filedb({"route": [(41, 2088, 1, 0)]})
+        outer = wrap_as_outer([inner])
+        section = parse_tag_section(outer, detect_version(outer))
+        triples = list(Anno117Interpreter().find_traded_goods(outer, section))
+        assert triples[0].context.route_name is None
+
+    def test_route_name_not_extracted_for_passive_kind(self) -> None:
+        """RouteName は ``kind='route'`` のときのみ拾う．passive では無視．"""
+        inner = make_inner_filedb(
+            {"passive": [(32777, 2142, -3, 156)]},
+        )
+        outer = wrap_as_outer([inner])
+        section = parse_tag_section(outer, detect_version(outer))
+        triples = list(Anno117Interpreter().find_traded_goods(outer, section))
+        assert triples[0].context.route_name is None
+
 
 class TestClassifyParentDirect:
     def test_too_short_stack_returns_none(self) -> None:
@@ -167,6 +208,24 @@ class TestFirstAttribHelpers:
         from anno_save_analyzer.trade.interpreter.anno117 import _first_int_attrib
 
         assert _first_int_attrib([{"X": b"\x00\x00\x00\x00"}], ("Tick",)) is None
+
+    def test_first_utf16_attrib_decodes_and_strips(self) -> None:
+        from anno_save_analyzer.trade.interpreter.anno117 import _first_utf16_attrib
+
+        stack = [{"RouteName": "\u200b商会ルート\u200b\x00\x00".encode("utf-16-le")}]
+        assert _first_utf16_attrib(stack, ("RouteName",)) == "商会ルート"
+
+    def test_first_utf16_attrib_returns_none_when_only_zwsp(self) -> None:
+        from anno_save_analyzer.trade.interpreter.anno117 import _first_utf16_attrib
+
+        stack = [{"RouteName": "\u200b\u200b".encode("utf-16-le")}]
+        assert _first_utf16_attrib(stack, ("RouteName",)) is None
+
+    def test_first_utf16_attrib_no_candidate_returns_none(self) -> None:
+        from anno_save_analyzer.trade.interpreter.anno117 import _first_utf16_attrib
+
+        stack = [{"Other": "x".encode("utf-16-le")}]
+        assert _first_utf16_attrib(stack, ("RouteName",)) is None
 
 
 class TestBuildTripleEdgeCases:

--- a/tests/tui/test_screens.py
+++ b/tests/tui/test_screens.py
@@ -268,7 +268,8 @@ class TestFilteredRenderingAndExport:
 
         routes_csv = next(tmp_path.glob("fake_routes_session-*_*.csv"))
         rows = routes_csv.read_text(encoding="utf-8").splitlines()
-        assert any(row.startswith("999,idle,route,") for row in rows)
+        # columns: route_id, route_name, status, partner_kind, ...
+        assert any(row.startswith("999,,idle,route,") for row in rows)
 
     async def test_export_filename_suffix_is_sanitized(
         self, tui_state, tmp_path, monkeypatch
@@ -630,12 +631,12 @@ class TestStatisticsScreen:
                 for i in range(routes_table.row_count)
             ]
             statuses = [row[1] for row in all_rows]
-            route_ids = [row[0] for row in all_rows]
+            route_labels = [row[0] for row in all_rows]
             assert "idle" in statuses
             assert "active" in statuses
-            assert "999" in route_ids
+            assert "#999" in route_labels
             # active row (ship=7) の legs は active_def.tasks=1 に反映されてる
-            row_7 = next(row for row in all_rows if row[0] == "7")
+            row_7 = next(row for row in all_rows if row[0] == "#7")
             assert row_7[3] == "1"  # Legs
             _ = active_ids
 


### PR DESCRIPTION
## Summary (EN)

Walks the Anno 117 ``TradeRouteEntries > <1> > <1>`` RouteName attrib and threads it through the pipeline so custom trade route names appear wherever ``route_id`` did — routes-table, Partners pane, and CSV / JSON exports.

- **interpreter**: new ``_first_utf16_attrib`` helper pulls ``RouteName`` (UTF-16-LE, U+200B stripped, same sanitization as ``CityName``) for ``kind='route'`` triples only
- **aggregate**: ``RouteSummary`` / ``PartnerSummary`` gain ``route_name`` + ``display_route`` / ``display_partner`` with ``route_name > #route_id > —`` fallback. ``by_route`` picks the latest-tick value when a route is renamed mid-playthrough
- **exports**: ``routes_to_csv`` / ``events_to_csv`` / ``events_to_json`` get a ``route_name`` column / field
- **TUI**: statistics routes-table uses ``display_route``; idle-route rows now render as ``#<ship_id>`` for symmetry with active rows

Real-save smoke on ``sample_anno117.a8s``: **59 / 60** routes now show the 書記長-chosen names (e.g. ``麻 ダイナ - ホッカ``) instead of bare ship IDs.

---

## 概要 (JA)

Anno 117 の ``TradeRouteEntries > <1> > <1>`` 配下にある ``RouteName`` attrib を interpreter で拾って ``ExtractionContext`` → ``TradeEvent`` → 集計サマリまで流し，これまで ``#<route_id>`` としか出せなかった全表示箇所 (routes-table / Partners pane / CSV・JSON export) で書記長命名ルート名を出すようにした．

- **interpreter**: ``_first_utf16_attrib`` ヘルパを追加．``CityName`` と同じ U+200B strip．``kind='route'`` 限定
- **aggregate**: ``RouteSummary`` / ``PartnerSummary`` に ``route_name`` + ``display_route`` / ``display_partner``．fallback は ``route_name > #route_id > —``．``by_route`` は rename に耐えるよう tick 進行で上書き
- **exports**: ``routes_to_csv`` / ``events_to_csv`` / ``events_to_json`` に ``route_name`` 列／フィールド追加
- **TUI**: routes-table は ``display_route``．idle 行も ``#<ship_id>`` 形式に揃えた

実セーブ smoke: 60 ルート中 **59** が書記長命名ルート名で表示確認．

Closes #40

## Test plan
- [x] pytest 全 418 件 pass（うち route_name 関連の新規テスト: interpreter 4 / helpers 3 / aggregate 3 / exports 2）
- [x] line + branch coverage 99.42%（90% floor 達成）
- [x] ruff check / format 完全クリーン
- [x] ``sample_anno117.a8s`` 実セーブで 59/60 ルートが書記長命名名で表示されるのを確認
- [x] idle ルート行 (``#<ship_id>``) が active 行 (``#<route_id>`` or ``<name>``) と整合する