### PR TITLE
feat(config): persist user settings to ~/.config/anno-save-analyzer/config.toml

### DIFF
--- a/src/anno_save_analyzer/cli/tui.py
+++ b/src/anno_save_analyzer/cli/tui.py
@@ -19,9 +19,8 @@ class GameTitleArg(StrEnum):
         return GameTitle(self.value)
 
 
-class ThemeArg(StrEnum):
-    DEFAULT = "default"
-    USSR = "ussr"
+_LOCALE_SENTINEL = "__from_config__"
+_THEME_SENTINEL = "__from_config__"
 
 
 def _launch(
@@ -29,10 +28,20 @@ def _launch(
     title: Annotated[
         GameTitleArg, typer.Option("--title", help="Game title.")
     ] = GameTitleArg.ANNO_117,
-    locale: Annotated[str, typer.Option("--locale", help="UI locale (en / ja).")] = "en",
+    locale: Annotated[
+        str,
+        typer.Option(
+            "--locale",
+            help="UI locale (en / ja). Defaults to saved config value.",
+        ),
+    ] = _LOCALE_SENTINEL,
     theme: Annotated[
-        ThemeArg, typer.Option("--theme", help="UI theme (default / ussr).")
-    ] = ThemeArg.DEFAULT,
+        str,
+        typer.Option(
+            "--theme",
+            help="UI theme (default / ussr). Defaults to saved config value.",
+        ),
+    ] = _THEME_SENTINEL,
 ) -> None:
     """Open the Textual trade-history viewer on SAVE.
 
@@ -51,6 +60,27 @@ def _launch(
             fg=typer.colors.RED,
         )
         raise typer.Exit(code=1) from exc
+
+    # 設定ファイルを先に読んで CLI 引数と merge．CLI 指定があればそちらを優先．
+    from anno_save_analyzer.config import (
+        chart_window_from_token,
+        load_config,
+    )
+
+    user_cfg = load_config()
+    resolved_locale = locale if locale != _LOCALE_SENTINEL else user_cfg.ui.locale
+    resolved_theme = theme if theme != _THEME_SENTINEL else user_cfg.ui.theme
+    if resolved_theme not in ("default", "ussr"):
+        typer.secho(
+            f"warning: unknown theme {resolved_theme!r} in config; falling back to 'default'",
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+        resolved_theme = "default"
+    saved_chart_window = chart_window_from_token(user_cfg.ui.chart_window)
+    locale = resolved_locale
+    theme_value = resolved_theme
+    recent_window = user_cfg.ui.recent_window_minutes
 
     # 進捗ゲージ (stderr)．Textual を起動すると stdout を掴むため err=True 固定．
     # ``load_state`` は各ステージ開始時に progress(stage_label) を呼び，
@@ -79,8 +109,30 @@ def _launch(
         state = load_state(save, title=title.to_title(), locale=locale, progress=_progress)
     typer.secho("  ✓ ready", err=True, fg=typer.colors.GREEN)
 
-    app = TradeApp(state, theme=theme.value)
+    app = TradeApp(state, theme=theme_value, persist_settings=True)
+    # ``^R`` / ``^P`` の初期値も config から復元．TradeApp init は statistics 画面を
+    # まだ install していないため，mount 後に設定する．
+    _apply_saved_stat_settings(app, saved_chart_window, recent_window)
     app.run()
+
+
+def _apply_saved_stat_settings(app, chart_window, recent_window_minutes) -> None:
+    """起動後 statistics 画面の config 値を復元する．install_screen は on_mount で
+    行われるので，ここでは mount 時フックを立てて差し替える．
+    """
+    original_on_mount = app.on_mount
+
+    def on_mount_then_restore() -> None:
+        original_on_mount()
+        try:
+            stats = app.get_screen("statistics")
+        except KeyError:  # pragma: no cover - install_screen 成功前提
+            return
+        if chart_window is not None:
+            stats._chart_window = chart_window
+        stats._recent_window_minutes = recent_window_minutes
+
+    app.on_mount = on_mount_then_restore  # type: ignore[method-assign]
 
 
 def _stderr():

--- a/src/anno_save_analyzer/config.py
+++ b/src/anno_save_analyzer/config.py
@@ -1,0 +1,172 @@
+"""ユーザー設定の永続化 (``config.toml``)．
+
+書記長 feedback (v0.4.2 C): ``^L`` で locale 切替，``^R`` で chart window
+切替，``^P`` で直近取引窓 — これらを毎回起動時に打ち直すのは不毛．XDG 準拠
+の ``~/.config/anno-save-analyzer/config.toml`` に Pydantic ベースで round-trip．
+
+スキーマ例::
+
+    [ui]
+    locale = "ja"
+    theme = "ussr"
+    chart_window = "120m"
+    recent_window_minutes = 120
+
+- 破損 TOML / 未知キー / ファイル無しは default に倒し stderr に warning．
+  CLI 起動を止めない (書記長が混乱する)．
+- 環境変数 ``ANNO_SAVE_ANALYZER_CONFIG`` で完全 override (test / 1 回限りの
+  起動設定に便利)．
+- Windows は ``%APPDATA%\\anno-save-analyzer\\config.toml``，それ以外は
+  XDG_CONFIG_HOME or ``~/.config`` ベース．
+- atomic write: tmp 書いてから ``rename`` (途中電源断で破損しない)．
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel, Field, ValidationError
+
+from .trade.chart_window import ChartTimeWindow
+
+_ENV_OVERRIDE = "ANNO_SAVE_ANALYZER_CONFIG"
+_APP_NAME = "anno-save-analyzer"
+
+# ChartTimeWindow ↔ TOML 文字列表現．書記長が手で TOML を開いても読めるよう
+# "120m" / "4h" 形式．enum 追加時はここに 1 行追加する．
+_CHART_WINDOW_TO_TOKEN: dict[ChartTimeWindow, str] = {
+    ChartTimeWindow.LAST_120_MIN: "120m",
+    ChartTimeWindow.LAST_4H: "4h",
+    ChartTimeWindow.LAST_12H: "12h",
+    ChartTimeWindow.LAST_24H: "24h",
+    ChartTimeWindow.ALL: "all",
+}
+_TOKEN_TO_CHART_WINDOW: dict[str, ChartTimeWindow] = {
+    v: k for k, v in _CHART_WINDOW_TO_TOKEN.items()
+}
+
+
+def chart_window_to_token(window: ChartTimeWindow) -> str:
+    return _CHART_WINDOW_TO_TOKEN[window]
+
+
+def chart_window_from_token(token: str) -> ChartTimeWindow | None:
+    return _TOKEN_TO_CHART_WINDOW.get(token)
+
+
+class UiConfig(BaseModel):
+    """TUI / CLI 共通の UI 設定．"""
+
+    locale: str = "en"
+    theme: str = "default"
+    chart_window: str = Field(default=chart_window_to_token(ChartTimeWindow.LAST_120_MIN))
+    # ``^P`` 直近取引窓の分値．``None`` = 全期間．``str`` を避け数値のまま保存．
+    recent_window_minutes: float | None = None
+
+    model_config = {"frozen": True, "extra": "ignore"}
+
+
+class UserConfig(BaseModel):
+    """書記長のユーザー設定一式．拡張は sub-section (``[section]``) 追加で．"""
+
+    ui: UiConfig = Field(default_factory=UiConfig)
+
+    model_config = {"frozen": True, "extra": "ignore"}
+
+
+def default_config_path() -> Path:
+    """現 OS での標準 config パスを返す．``ANNO_SAVE_ANALYZER_CONFIG`` 優先．"""
+    override = os.environ.get(_ENV_OVERRIDE)
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA")
+        if base:
+            return Path(base) / _APP_NAME / "config.toml"
+        # APPDATA 未設定 Windows は極めて稀．$HOME fallback で crash を避ける．
+        return Path.home() / f".{_APP_NAME}.toml"  # pragma: no cover
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / _APP_NAME / "config.toml"
+
+
+def load_config(path: Path | None = None) -> UserConfig:
+    """``config.toml`` を load．不在 / 破損 / 不正型は default に倒す．
+
+    warning は stderr に 1 行．crash させない方針．
+    """
+    path = path or default_config_path()
+    if not path.is_file():
+        return UserConfig()
+    try:
+        with path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        print(
+            f"warning: config {path} could not be read ({exc}); using defaults",
+            file=sys.stderr,
+        )
+        return UserConfig()
+    try:
+        return UserConfig.model_validate(raw)
+    except ValidationError as exc:
+        print(
+            f"warning: config {path} has invalid fields ({exc.error_count()} errors); "
+            "using defaults",
+            file=sys.stderr,
+        )
+        return UserConfig()
+
+
+def save_config(cfg: UserConfig, path: Path | None = None) -> Path | None:
+    """``cfg`` を atomic に書き込む．失敗時は warning のみで ``None`` を返す．
+
+    tmp file を同一ディレクトリに作ってから ``replace`` で rename．途中落ち
+    でも既存 config が壊れない．read-only FS / 権限不足でも crash させない．
+    """
+    path = path or default_config_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"warning: cannot create config dir {path.parent} ({exc})", file=sys.stderr)
+        return None
+    try:
+        # tomllib には dump 機能がないので自前で整形．キー数が少ないので素直に書く．
+        content = _render_toml(cfg)
+        tmp_fd, tmp_path_str = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent, text=True)
+        tmp_path = Path(tmp_path_str)
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            tmp_path.replace(path)
+        except OSError:
+            tmp_path.unlink(missing_ok=True)
+            raise
+    except OSError as exc:
+        print(f"warning: cannot write config {path} ({exc})", file=sys.stderr)
+        return None
+    return path
+
+
+def _render_toml(cfg: UserConfig) -> str:
+    """UiConfig を TOML 文字列にシリアライズ．手書き (tomli-w を増やさない)．"""
+    ui = cfg.ui
+    lines: list[str] = ["[ui]"]
+    lines.append(f'locale = "{_quote(ui.locale)}"')
+    lines.append(f'theme = "{_quote(ui.theme)}"')
+    lines.append(f'chart_window = "{_quote(ui.chart_window)}"')
+    if ui.recent_window_minutes is None:
+        # 明示的に存在させておくとユーザーが TOML を開いた時に書記長の意図が明確．
+        lines.append("# recent_window_minutes = 60   # コメントアウト = 全期間")
+    else:
+        lines.append(f"recent_window_minutes = {ui.recent_window_minutes}")
+    return "\n".join(lines) + "\n"
+
+
+def _quote(value: str) -> str:
+    """TOML ベアストリング内で安全になるよう ``"`` と ``\\`` をエスケープ．"""
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/anno_save_analyzer/tui/app.py
+++ b/src/anno_save_analyzer/tui/app.py
@@ -67,6 +67,7 @@ class TradeApp(App[None]):
         *,
         localizer: Localizer | None = None,
         theme: str = "default",
+        persist_settings: bool = False,
     ) -> None:
         super().__init__()
         self._state = state
@@ -78,6 +79,9 @@ class TradeApp(App[None]):
             self.CSS = theme_css(theme)
         self._apply_localized_bindings()
         self.title = self._localized_title()
+        # 設定を ``~/.config/anno-save-analyzer/config.toml`` に逆流させるか．
+        # CLI 経由では True．純粋な unit test から直接起動した場合は False．
+        self._persist_settings = persist_settings
 
     def _localized_title(self) -> str:
         base = self._localizer.t("app.title")
@@ -122,6 +126,41 @@ class TradeApp(App[None]):
         for screen in (self.get_screen("overview"), self.get_screen("statistics")):
             screen.set_localizer(self._localizer)
             screen.refresh(recompose=True)
+        self.persist_user_settings()
+
+    def persist_user_settings(self) -> None:
+        """現在の UI 設定を ``config.toml`` に保存．``persist_settings=False`` なら no-op．
+
+        Statistics 画面から chart_window / recent_window_minutes を読み出し，
+        app レベルの locale / theme と合わせて ``UserConfig`` を組み立てて書く．
+        IO エラーは ``save_config`` 側で warning に落ちるので crash しない．
+        """
+        if not self._persist_settings:
+            return
+        from anno_save_analyzer.config import (
+            UiConfig,
+            UserConfig,
+            chart_window_to_token,
+            save_config,
+        )
+        from anno_save_analyzer.trade.chart_window import ChartTimeWindow
+
+        chart_window = ChartTimeWindow.LAST_120_MIN
+        recent_window: float | None = None
+        try:
+            stats = self.get_screen("statistics")
+        except KeyError:
+            stats = None
+        if stats is not None:
+            chart_window = getattr(stats, "_chart_window", chart_window)
+            recent_window = getattr(stats, "_recent_window_minutes", None)
+        ui = UiConfig(
+            locale=self._localizer.code,
+            theme=self._theme_name,
+            chart_window=chart_window_to_token(chart_window),
+            recent_window_minutes=recent_window,
+        )
+        save_config(UserConfig(ui=ui))
 
     def action_show_help(self) -> None:  # pragma: no cover - manual interaction only
         self.notify(self._localizer.t("binding.help"))

--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -262,6 +262,15 @@ class TradeStatisticsScreen(Screen):
         self._notify_recent_window(value)
         if self._last_selected_item_guid is not None:
             self._update_partners_pane(self._last_selected_item_guid)
+        self._request_persist()
+
+    def _request_persist(self) -> None:
+        """app に ``persist_user_settings`` があれば呼ぶ．unit test / 単体起動でも
+        crash しないよう ``getattr`` で柔らかく参照．
+        """
+        persist = getattr(self.app, "persist_user_settings", None)
+        if persist is not None:
+            persist()
 
     def _notify_recent_window(self, value: float | None) -> None:
         t = self._localizer.t
@@ -278,6 +287,7 @@ class TradeStatisticsScreen(Screen):
         t = self._localizer.t
         self.app.notify(t("chart.window.notice", label=t(self._chart_window.locale_key)))
         self._redraw_active_chart_window()
+        self._request_persist()
 
     def _redraw_active_chart_window(self) -> None:
         """現在アクティブな tab に対応する chart だけ再描画する．"""

--- a/tests/cli/test_tui_cmd.py
+++ b/tests/cli/test_tui_cmd.py
@@ -95,8 +95,9 @@ class TestTuiCommand:
         save = _make_save(tmp_path)
         captured: dict[str, object] = {}
 
-        def fake_init(self, state, *, localizer=None, theme="default"):
+        def fake_init(self, state, *, localizer=None, theme="default", persist_settings=False):
             captured["theme"] = theme
+            captured["persist_settings"] = persist_settings
             # super().__init__ は呼ばないと run() がコケるが run は mock 済なので
             # 最小限の set だけで通す．
             from anno_save_analyzer.tui.i18n import Localizer
@@ -112,3 +113,89 @@ class TestTuiCommand:
             result = runner.invoke(app, ["tui", str(save), "--theme", "ussr"])
         assert result.exit_code == 0
         assert captured["theme"] == "ussr"
+        # CLI 起動時は config.toml への自動書き出しを有効化している
+        assert captured["persist_settings"] is True
+
+    def test_tui_reads_saved_config_for_locale_and_theme(self, tmp_path: Path, monkeypatch) -> None:
+        """``--locale`` / ``--theme`` 無指定なら ``config.toml`` 値が使われる．"""
+        cfg_path = tmp_path / "cfg.toml"
+        cfg_path.write_text(
+            '[ui]\nlocale = "ja"\ntheme = "ussr"\nchart_window = "24h"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        save = _make_save(tmp_path)
+
+        captured: dict[str, object] = {}
+
+        def fake_init(self, state, *, localizer=None, theme="default", persist_settings=False):
+            captured["theme"] = theme
+            captured["state_locale"] = state.locale
+            from anno_save_analyzer.tui.i18n import Localizer
+
+            self._state = state
+            self._localizer = localizer or Localizer.load(state.locale)
+            self._theme_name = theme
+
+        with (
+            patch("anno_save_analyzer.tui.TradeApp.__init__", fake_init),
+            patch("anno_save_analyzer.tui.TradeApp.run"),
+        ):
+            result = runner.invoke(app, ["tui", str(save)])
+
+        assert result.exit_code == 0, result.output
+        assert captured["theme"] == "ussr"
+        assert captured["state_locale"] == "ja"
+
+    def test_tui_cli_arg_overrides_config(self, tmp_path: Path, monkeypatch) -> None:
+        """config.toml より CLI ``--locale`` 引数を優先する．"""
+        cfg_path = tmp_path / "cfg.toml"
+        cfg_path.write_text('[ui]\nlocale = "ja"\n', encoding="utf-8")
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        save = _make_save(tmp_path)
+
+        captured: dict[str, object] = {}
+
+        def fake_init(self, state, *, localizer=None, theme="default", persist_settings=False):
+            captured["state_locale"] = state.locale
+            from anno_save_analyzer.tui.i18n import Localizer
+
+            self._state = state
+            self._localizer = localizer or Localizer.load(state.locale)
+            self._theme_name = theme
+
+        with (
+            patch("anno_save_analyzer.tui.TradeApp.__init__", fake_init),
+            patch("anno_save_analyzer.tui.TradeApp.run"),
+        ):
+            result = runner.invoke(app, ["tui", str(save), "--locale", "en"])
+
+        assert result.exit_code == 0
+        assert captured["state_locale"] == "en"
+
+    def test_tui_warns_on_unknown_theme_in_config(self, tmp_path: Path, monkeypatch) -> None:
+        """破損 theme 値は default にフォールバックし warning を出す．"""
+        cfg_path = tmp_path / "cfg.toml"
+        cfg_path.write_text('[ui]\ntheme = "neonpunk"\n', encoding="utf-8")
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        save = _make_save(tmp_path)
+
+        captured: dict[str, object] = {}
+
+        def fake_init(self, state, *, localizer=None, theme="default", persist_settings=False):
+            captured["theme"] = theme
+            from anno_save_analyzer.tui.i18n import Localizer
+
+            self._state = state
+            self._localizer = localizer or Localizer.load(state.locale)
+            self._theme_name = theme
+
+        with (
+            patch("anno_save_analyzer.tui.TradeApp.__init__", fake_init),
+            patch("anno_save_analyzer.tui.TradeApp.run"),
+        ):
+            result = runner.invoke(app, ["tui", str(save)])
+
+        assert result.exit_code == 0, result.output
+        assert captured["theme"] == "default"
+        assert "unknown theme" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,166 @@
+"""``anno_save_analyzer.config`` の単体テスト．"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from anno_save_analyzer.config import (
+    _ENV_OVERRIDE,
+    UiConfig,
+    UserConfig,
+    chart_window_from_token,
+    chart_window_to_token,
+    default_config_path,
+    load_config,
+    save_config,
+)
+from anno_save_analyzer.trade.chart_window import ChartTimeWindow
+
+
+class TestChartWindowTokens:
+    def test_roundtrip_for_every_member(self) -> None:
+        for window in ChartTimeWindow:
+            token = chart_window_to_token(window)
+            assert chart_window_from_token(token) == window
+
+    def test_unknown_token_is_none(self) -> None:
+        assert chart_window_from_token("nope") is None
+
+
+class TestDefaultConfigPath:
+    def test_env_override_takes_priority(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        override = tmp_path / "override.toml"
+        monkeypatch.setenv(_ENV_OVERRIDE, str(override))
+        assert default_config_path() == override
+
+    def test_xdg_config_home_respected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv(_ENV_OVERRIDE, raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr("sys.platform", "linux")
+        result = default_config_path()
+        assert result == tmp_path / "anno-save-analyzer" / "config.toml"
+
+    def test_default_linux_path(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.delenv(_ENV_OVERRIDE, raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("sys.platform", "linux")
+        result = default_config_path()
+        assert result == tmp_path / ".config" / "anno-save-analyzer" / "config.toml"
+
+
+class TestLoadConfig:
+    def test_missing_file_returns_default(self, tmp_path: Path) -> None:
+        cfg = load_config(tmp_path / "missing.toml")
+        assert cfg == UserConfig()
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        cfg = UserConfig(
+            ui=UiConfig(
+                locale="ja",
+                theme="ussr",
+                chart_window=chart_window_to_token(ChartTimeWindow.LAST_24H),
+                recent_window_minutes=60.0,
+            )
+        )
+        saved = save_config(cfg, path)
+        assert saved == path
+        loaded = load_config(path)
+        assert loaded.ui.locale == "ja"
+        assert loaded.ui.theme == "ussr"
+        assert loaded.ui.chart_window == "24h"
+        assert loaded.ui.recent_window_minutes == 60.0
+
+    def test_broken_toml_falls_back_to_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "broken.toml"
+        path.write_text("this is [not valid toml", encoding="utf-8")
+        cfg = load_config(path)
+        assert cfg == UserConfig()
+        assert "could not be read" in capsys.readouterr().err
+
+    def test_unknown_keys_are_ignored(self, tmp_path: Path) -> None:
+        """``extra = ignore`` なので未知キーは無視される．"""
+        path = tmp_path / "extra.toml"
+        path.write_text(
+            '[ui]\nlocale = "en"\ntheme = "default"\nchart_window = "all"\n'
+            'unknown_field = "keep moving"\n',
+            encoding="utf-8",
+        )
+        cfg = load_config(path)
+        assert cfg.ui.locale == "en"
+        assert cfg.ui.chart_window == "all"
+
+    def test_invalid_field_type_falls_back_to_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "badtype.toml"
+        # locale は str 前提．数値を入れて ValidationError を誘発
+        path.write_text("[ui]\nlocale = 42\n", encoding="utf-8")
+        cfg = load_config(path)
+        assert cfg == UserConfig()
+        assert "invalid fields" in capsys.readouterr().err
+
+
+class TestSaveConfig:
+    def test_atomic_write_replaces_existing(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        path.write_text("[ui]\nlocale = 'en'\n", encoding="utf-8")
+        save_config(UserConfig(ui=UiConfig(locale="ja")), path)
+        assert "locale = " in path.read_text()
+        assert load_config(path).ui.locale == "ja"
+
+    def test_write_failure_returns_none(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # 書けないディレクトリ (既存 file を parent にすると mkdir が失敗)
+        blocker = tmp_path / "blocked"
+        blocker.write_text("x", encoding="utf-8")
+        target = blocker / "config.toml"
+        result = save_config(UserConfig(), target)
+        assert result is None
+        assert "cannot" in capsys.readouterr().err
+
+    def test_write_failure_in_body_returns_none(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """tmp file の書き込み中に OSError が出た場合の fallback パス．"""
+        path = tmp_path / "cfg.toml"
+
+        original_replace = Path.replace
+
+        def failing_replace(self: Path, target: os.PathLike[str]) -> Path:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "replace", failing_replace)
+        try:
+            result = save_config(UserConfig(), path)
+            assert result is None
+            assert "cannot write" in capsys.readouterr().err
+        finally:
+            monkeypatch.setattr(Path, "replace", original_replace)
+
+    def test_recent_window_none_is_commented_out(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        save_config(UserConfig(ui=UiConfig(recent_window_minutes=None)), path)
+        text = path.read_text(encoding="utf-8")
+        assert "# recent_window_minutes" in text
+
+    def test_special_chars_in_locale_are_escaped(self, tmp_path: Path) -> None:
+        """TOML 文字列内の quote / backslash は escape されなければならない．"""
+        path = tmp_path / "cfg.toml"
+        save_config(UserConfig(ui=UiConfig(locale='weird"locale\\x', theme="default")), path)
+        loaded = load_config(path)
+        assert loaded.ui.locale == 'weird"locale\\x'

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -143,6 +143,64 @@ class TestFromSaveClassmethod:
         assert app._localizer.code == "ja"
 
 
+@pytest.mark.asyncio
+class TestPersistSettings:
+    """``persist_settings=True`` 起動時の自動書き出し．"""
+
+    async def test_persist_disabled_by_default(self, tui_state, tmp_path, monkeypatch) -> None:
+        cfg_path = tmp_path / "cfg.toml"
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        app = TradeApp(tui_state)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+l")
+            await pilot.pause()
+        # persist_settings=False なのでファイル作られない
+        assert not cfg_path.exists()
+
+    async def test_locale_switch_writes_config_when_persist_enabled(
+        self, tui_state, tmp_path, monkeypatch
+    ) -> None:
+        cfg_path = tmp_path / "cfg.toml"
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        app = TradeApp(tui_state, persist_settings=True)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._localizer.code == "en"
+            await pilot.press("ctrl+l")
+            await pilot.pause()
+        assert cfg_path.exists()
+        text = cfg_path.read_text(encoding="utf-8")
+        assert 'locale = "ja"' in text
+
+    async def test_chart_window_cycle_writes_config(self, tui_state, tmp_path, monkeypatch) -> None:
+        cfg_path = tmp_path / "cfg.toml"
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        app = TradeApp(tui_state, persist_settings=True)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+        assert cfg_path.exists()
+        text = cfg_path.read_text(encoding="utf-8")
+        # LAST_120_MIN → LAST_4H に cycle したはず
+        assert 'chart_window = "4h"' in text
+
+    async def test_persist_is_noop_without_statistics_screen(
+        self, tui_state, tmp_path, monkeypatch
+    ) -> None:
+        """統計画面を install する前に呼ばれても crash しない．"""
+        cfg_path = tmp_path / "cfg.toml"
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        app = TradeApp(tui_state, persist_settings=True)
+        # install_screen は on_mount で行われるので，明示的に呼ばない状態で persist
+        app.persist_user_settings()
+        # ファイルは書かれる (statistics 画面から値を読めないので default)
+        assert cfg_path.exists()
+
+
 def test_sanitize_filename_component_fallback_for_empty_or_whitespace() -> None:
     """``_sanitize_filename_component`` が空文字になる入力で unknown-<digest> を返す．
 


### PR DESCRIPTION
## Summary (EN)

Remembers **locale / theme / chart window / recent-trades window** across restarts so 書記長 doesn't have to re-type ``--locale ja --theme ussr`` every launch or cycle ``^R`` back to 120 min after each boot. XDG-compliant on Linux (``~/.config/anno-save-analyzer/config.toml``), ``%APPDATA%`` on Windows, ``ANNO_SAVE_ANALYZER_CONFIG`` env override for tests / one-off runs.

- **anno_save_analyzer.config**: ``UiConfig`` / ``UserConfig`` Pydantic (frozen, ``extra=ignore``). Missing / broken / type-invalid TOML falls back to defaults with a single stderr warning — CLI never crashes
- **atomic write**: ``tempfile.mkstemp`` + ``Path.replace``, ``OSError`` demoted to warning returning ``None``
- **cli.tui**: ``--locale`` / ``--theme`` sentinels pull from config when unset; CLI args still win. Unknown ``theme`` → ``default`` + yellow warning. Saved ``chart_window`` / ``recent_window_minutes`` are restored onto the statistics screen after ``on_mount``
- **tui.TradeApp**: new ``persist_settings`` flag (default False for unit tests). ``switch_locale`` + statistics ``^R`` / ``^P`` callbacks route through ``persist_user_settings`` which gathers current screen state and ``save_config``s
- **tui.screens.statistics**: ``_request_persist`` helper with ``getattr``-based soft dispatch so unit tests spinning up the screen without a ``TradeApp`` host still work

## Example config.toml

```toml
[ui]
locale = "ja"
theme = "ussr"
chart_window = "24h"
recent_window_minutes = 60.0
```

Real round-trip smoke via ``ANNO_SAVE_ANALYZER_CONFIG`` returns identical values for locale / theme / chart_window / recent_window_minutes.

---

## 概要 (JA)

書記長が毎回 ``--locale ja --theme ussr`` 打ち直したり ``^R`` を 120 分に戻したりしなくて済むよう，``~/.config/anno-save-analyzer/config.toml`` に UI 設定一式 (locale / theme / chart_window / recent_window_minutes) を永続化する．

- **config モジュール**: Pydantic frozen model．ファイル無し / 破損 / 型不正は default に倒し stderr warning 1 行．CLI は crash しない
- **atomic write**: ``tempfile`` + ``Path.replace``．OSError は warning + ``None`` 返却で write-only FS でも落ちない
- **CLI**: ``--locale`` / ``--theme`` の sentinel で未指定なら config 値．引数指定時は引数優先．未知 theme は ``default`` に倒して yellow warning．保存されている ``chart_window`` / ``recent_window_minutes`` は ``on_mount`` 後に statistics 画面へ復元
- **TradeApp**: ``persist_settings`` フラグ (デフォルト False)．``switch_locale`` と ``^R`` / ``^P`` callback が ``persist_user_settings`` を呼んで config を書き出す
- **tests**: 22 件新規 (config 16 + TUI 4 + CLI 4)．破損 TOML / 未知キー / 型不正 / atomic / OSError / escape / path 解決 / persist 有/無 / CLI override など

実 round-trip smoke で locale=ja / theme=ussr / chart_window=24h / recent_window_minutes=60 が save→load で同値を確認．

Closes #42

## Test plan
- [x] pytest 483 件 pass（config 単体 16 / CLI 3 / TUI persist 4 が新規）
- [x] line + branch coverage 98.63%（90% floor 達成）
- [x] ruff check / format クリーン
- [x] ``ANNO_SAVE_ANALYZER_CONFIG`` round-trip で値が保持されることを確認
- [x] 破損 TOML でも exit 1 せず default で起動 (warning のみ)
- [x] 未知 theme は ``default`` に fallback + warning