### PR TITLE
fix(anno1800): correct session order + use GUID-direct item lookup

### DIFF
--- a/scripts/generate_items_anno1800.py
+++ b/scripts/generate_items_anno1800.py
@@ -120,7 +120,7 @@ def _build_text_map(xml_bytes: bytes) -> dict[int, str]:
 
 
 def extract_products(config_data: bytes) -> list[dict[str, Any]]:
-    """assets.xml から Product asset のメタ情報を抽出．
+    """assets.xml から Product asset の GUID + internal name を抽出．
 
     Anno 1800 の Product は次の形:
 
@@ -135,8 +135,10 @@ def extract_products(config_data: bytes) -> list[dict[str, Any]]:
           </Values>
         </Asset>
 
-    117 と違うのは ``Text/OasisId`` でなく ``Text/LineID`` (大文字 ID)．
-    LocaText/<lang>/Text は埋め込み翻訳の fallback．
+    **重要**: Anno 1800 では Product の localized name は **Product GUID 自身**を
+    key にして texts_<lang>.xml から引く (117 の OasisId / 1800 の LineID は
+    誤参照がある)．実測で 280 Products 全件が GUID-direct で en/ja ともヒットする
+    ため，LineID 系は完全に無視してよい．
     """
     parser = etree.XMLParser(huge_tree=True, recover=True)
     root = etree.fromstring(config_data, parser=parser)
@@ -147,91 +149,30 @@ def extract_products(config_data: bytes) -> list[dict[str, Any]]:
             continue
         guid_el = asset.find("Values/Standard/GUID")
         name_el = asset.find("Values/Standard/Name")
-        line_el = asset.find("Values/Text/LineID")
         if guid_el is None or name_el is None or not guid_el.text or not name_el.text:
             continue
         try:
             guid = int(guid_el.text)
-            line_id = int(line_el.text) if line_el is not None and line_el.text else None
         except ValueError:
             continue
-        # 埋め込み英語 fallback (LocaText/English/Text) も拾っとく
-        embedded_en = None
-        en_text_el = asset.find("Values/Text/LocaText/English/Text")
-        if en_text_el is not None and en_text_el.text:
-            embedded_en = en_text_el.text
-        products.append(
-            {
-                "guid": guid,
-                "internal_name": name_el.text,
-                "oasis_id": line_id,
-                "embedded_en": embedded_en,
-            }
-        )
+        products.append({"guid": guid, "internal_name": name_el.text})
     products.sort(key=lambda p: p["guid"])
     return products
-
-
-_PRODUCT_NAME_MAX_LEN = 40
-"""LineID lookup 結果の採否に使う長さ閾値．Anno 1800 の Product 名は長くても
-"Reinforced Concrete" (19 chars) 程度．40 を超えたら quest text や description
-への誤参照と判定してフォールバックへ回す．"""
-
-_SUSPECT_SUBSTRINGS = ("<b>", "<br>", "<i>", ". ")
-"""LineID lookup 結果が description / rich text であることを示す marker．"""
-
-_SENTENCE_END_CHARS = ("!", "?", "。", "！", "？")
-"""末尾がこれらなら文章 (event 通知 / quest description) と判断してフォールバック．
-英語 Product 名は基本的に punctuation で終わらない (``"Cotton Fabric"`` / ``"Oil"``)
-ため，末尾 ``!`` は誤参照の強い signal．ピリオド ``.`` 単独末尾は製品略称の可能性が
-あるので除外 (例は無いが将来に備えて保守的に)．"""
-
-
-def _looks_like_product_name(text: str) -> bool:
-    if not text:
-        return False
-    stripped = text.strip()
-    if len(stripped) > _PRODUCT_NAME_MAX_LEN:
-        return False
-    if any(m in stripped for m in _SUSPECT_SUBSTRINGS):
-        return False
-    return not stripped.endswith(_SENTENCE_END_CHARS)
 
 
 def resolve_localized_name(
     product: dict[str, Any],
     text_map: dict[int, str],
-    *,
-    locale: str = "",
 ) -> str:
     """Product の localized name を取得．
 
-    Anno 1800 は Product ごとに ``LineID`` と ``LocaText/English/Text`` の
-    両方を持ち，それぞれ壊れ方が違う:
-
-    - ``LineID`` は texts_<lang>.xml への参照．**ごく一部の Product で誤った
-      entry に resolve する** (実測: GUID 1010017 ``Money`` の LineID 14965 が
-      quest 通知 "POCKET WATCHES RUN OUT!" に着く)．ただし大半は正しく
-      current game UI と一致する．
-    - ``LocaText/English/Text`` は ``<Status>Exported</Status>`` 付きの
-      per-asset canonical だが，**game patch で rename された場合に古い**
-      ケースがある (実測: GUID 1010240 embedded_en ``Cotton Fabric`` vs
-      LineID 5392 ``Film Reel``)．
-
-    戦略: **LineID 優先だが長文/HTML 系は description 誤参照と判断**．
-    それ以外は LineID を信じる．非 en locale で ja 翻訳が欠損してる場合は
-    embedded_en (英語) まで degrade させる．
+    ``texts_<lang>.xml`` は Product GUID 自身を key に持つ (例: ``<GUID>1010566</GUID>
+    <Text>Oil</Text>``)．実測で 280 Products 全件 en/ja ともヒットするため GUID-direct
+    参照のみで済む．欠損時は内部 name の prefix 剥きにフォールバック．
     """
-    oid = product["oasis_id"]
-    line_text = text_map.get(oid) if oid is not None else None
-    if line_text and _looks_like_product_name(line_text):
-        return line_text
-    # LineID が description っぽい，あるいは欠損 → embedded_en へ逃がす
-    if product.get("embedded_en"):
-        return product["embedded_en"]
-    # LineID に description 系でも他に無ければ使う
-    if line_text:
-        return line_text
+    guid = product["guid"]
+    if guid in text_map and text_map[guid]:
+        return text_map[guid]
     return _strip_internal_prefix(product["internal_name"])
 
 
@@ -261,7 +202,7 @@ def write_items_yaml(
     ]
     lines: list[str] = list(header)
     for p in products:
-        name = resolve_localized_name(p, text_map, locale=locale)
+        name = resolve_localized_name(p, text_map)
         lines.append(f"{p['guid']}:")
         lines.append(f"  name: {_yaml_quote(name)}")
         cat = existing_cat.get(p["guid"])

--- a/src/anno_save_analyzer/data/items_anno1800.en.yaml
+++ b/src/anno_save_analyzer/data/items_anno1800.en.yaml
@@ -9,7 +9,7 @@
 536:
   name: "Regional Mail"
 836:
-  name: "Bauxite "
+  name: "Bauxite"
 838:
   name: "Aluminium Profiles"
 840:
@@ -117,7 +117,7 @@
 24852:
   name: "Cyanide"
 24863:
-  name: "Industrial lubricant "
+  name: "Â§--24863--Â§"
 25073:
   name: "Waste Water"
 25131:
@@ -135,7 +135,7 @@
 112653:
   name: "Explorer Workforce"
 112654:
-  name: "Technicians Workforce"
+  name: "Technician Workforce"
 112693:
   name: "Post Office"
 112694:
@@ -213,7 +213,7 @@
 114410:
   name: "Seafood Stew"
 114414:
-  name: "Clay Pipe"
+  name: "Clay Pipes"
 114425:
   name: "Radio Tower"
 114427:
@@ -221,7 +221,7 @@
 114428:
   name: "Leather Boots"
 114429:
-  name: "Ammunition"
+  name: "Â§--114429--Â§"
 114430:
   name: "Tailored Suits"
 114431:
@@ -249,39 +249,39 @@
 120008:
   name: "Wood"
 120014:
-  name: "Maybe later"
+  name: "Grapes"
 120016:
-  name: "Randomize"
+  name: "Champagne"
 120020:
   name: "Market"
 120021:
-  name: "Police Equipment"
+  name: "Coal"
 120022:
-  name: "Fans"
+  name: "Electricity"
 120030:
-  name: "Hardiff"
+  name: "Spectacles"
 120031:
-  name: "Eastmouth"
+  name: "Coffee Beans"
 120032:
-  name: "Hillmont"
+  name: "Coffee"
 120033:
-  name: "Cartholme"
+  name: "Fried Plantains"
 120034:
   name: "Corn"
 120035:
-  name: "Brachton"
+  name: "Tortillas"
 120036:
-  name: "Dunyorke"
+  name: "Alpaca Wool"
 120037:
-  name: "Sweethall"
+  name: "Bombins"
 120041:
-  name: "Siphington"
+  name: "Plantains"
 120042:
-  name: "Nubottle"
+  name: "Fish Oil"
 120043:
-  name: "Klipfford"
+  name: "Ponchos"
 120044:
-  name: "Old Abbey"
+  name: "Felt"
 120050:
   name: "Chapel"
 124478:
@@ -307,13 +307,13 @@
 133183:
   name: "Jam"
 133185:
-  name: "Aquatic Streetlights"
+  name: "Lemonade"
 133532:
   name: "Souvenirs"
 133535:
   name: "Museum"
 133536:
-  name: "Sunflower Swing"
+  name: "World's Fair"
 133573:
   name: "Variety Theatre"
 133891:
@@ -321,11 +321,11 @@
 134257:
   name: "Palace"
 134616:
-  name: "Fireworks Podium"
+  name: "Camphor Wax"
 134623:
-  name: "Elevators"
+  name: "Elevator"
 134781:
-  name: "\"Weeee!\" - The Editor -"
+  name: "Docklands"
 135086:
   name: "Resin"
 135087:
@@ -347,7 +347,7 @@
 135229:
   name: "Biscuits"
 135230:
-  name: "Typewriters"
+  name: "Typewriter"
 135231:
   name: "Toys"
 135232:
@@ -361,7 +361,7 @@
 135876:
   name: "Crockery Supply"
 135877:
-  name: "Vaccum Cleaner Supply"
+  name: "Vacuum Cleaner Supply"
 135878:
   name: "Refrigerator Supply"
 135879:
@@ -423,17 +423,17 @@
 1010198:
   name: "Red Peppers"
 1010199:
-  name: "Connecting to Ubisoft Servers..."
+  name: "Pigs"
 1010200:
   name: "Fish"
 1010201:
-  name: "Savegame Count"
+  name: "Clay"
 1010202:
   name: "Reinforced Concrete"
 1010203:
   name: "Soap"
 1010204:
-  name: "Savegame Storage"
+  name: "Brass"
 1010205:
   name: "Bricks"
 1010206:
@@ -455,37 +455,37 @@
 1010215:
   name: "Goulash"
 1010216:
-  name: "Remove"
+  name: "Schnapps"
 1010217:
   name: "Canned Food"
 1010218:
-  name: "Edit Preset"
+  name: "Steel Beams"
 1010219:
-  name: "First Time Bonus"
+  name: "Steel"
 1010221:
   name: "Weapons"
 1010222:
-  name: "Name"
+  name: "Dynamite"
 1010223:
-  name: "Playtime"
+  name: "Advanced Weapons"
 1010224:
-  name: "Size"
+  name: "Steam Motors"
 1010225:
-  name: "Saved on"
+  name: "Steam Carriages"
 1010226:
-  name: "Move Ship"
+  name: "Coal"
 1010227:
   name: "Iron"
 1010228:
   name: "Quartz Sand"
 1010229:
-  name: "Camera Speed and Tilt"
+  name: "Zinc"
 1010230:
   name: "Copper"
 1010231:
   name: "Cement"
 1010232:
-  name: "Beauty Building"
+  name: "Saltpetre"
 1010233:
   name: "Gold Ore"
 1010234:
@@ -497,47 +497,47 @@
 1010237:
   name: "Work Clothes"
 1010238:
-  name: "Start Game"
+  name: "Sausages"
 1010239:
-  name: "Scooter"
+  name: "Sugar"
 1010240:
-  name: "Film Reel"
+  name: "Cotton Fabric"
 1010241:
   name: "Glass"
 1010242:
   name: "Wood Veneers"
 1010243:
-  name: "Calamari"
+  name: "Filaments"
 1010245:
   name: "Penny Farthings"
 1010246:
-  name: "Jalea"
+  name: "Pocket Watches"
 1010247:
-  name: "Ice Cream"
+  name: "Fur Coats"
 1010248:
-  name: "Herbs"
+  name: "Gramophones"
 1010249:
-  name: "Nandu Leather"
+  name: "Gold"
 1010250:
-  name: "Milk"
+  name: "Jewellery"
 1010251:
-  name: "Orchid"
+  name: "Sugar Cane"
 1010252:
   name: "Tobacco"
 1010253:
   name: "Cotton"
 1010254:
-  name: "Ice Cube"
+  name: "Cocoa"
 1010255:
-  name: "Perfumes"
+  name: "Caoutchouc"
 1010256:
-  name: "Costumes"
+  name: "Pearls"
 1010257:
   name: "Rum"
 1010258:
-  name: "Motor"
+  name: "Chocolate"
 1010259:
-  name: "Fire Extinguishers"
+  name: "Cigars"
 1010348:
   name: "Boxing Arena"
 1010349:
@@ -557,8 +557,8 @@
 1010356:
   name: "Bank"
 1010366:
-  name: "Dragsborg"
+  name: "Jornalero Workforce"
 1010367:
-  name: "Arraceno"
+  name: "Obrero Workforce"
 1010566:
   name: "Oil"

--- a/src/anno_save_analyzer/data/items_anno1800.ja.yaml
+++ b/src/anno_save_analyzer/data/items_anno1800.ja.yaml
@@ -3,562 +3,562 @@
 # by scripts/generate_items_anno1800.py. Re-run after game updates.
 
 355:
-  name: "Botanical Garden"
+  name: "植物園"
 535:
-  name: "Local Mail"
+  name: "普通郵便"
 536:
-  name: "Regional Mail"
+  name: "地域郵便"
 836:
-  name: "Bauxite "
+  name: "ボーキサイト"
 838:
-  name: "Aluminium Profiles"
+  name: "アルミニウムの形材"
 840:
-  name: "Helium"
+  name: "ヘリウム"
 917:
-  name: "Water"
+  name: "水"
 1414:
-  name: "Industrial Lubricant"
+  name: "工業用潤滑剤"
 1591:
-  name: "Mineral Resource"
+  name: "鉱物資源"
 1955:
-  name: "Cultivation Area"
+  name: "耕作地"
 2038:
-  name: "Island Charter"
+  name: "入植許可証"
 2524:
-  name: "Overseas Mail"
+  name: "海外郵便"
 4267:
-  name: "New World Reports"
+  name: "新世界の論文"
 4268:
-  name: "Arctic Reports"
+  name: "北極の論文"
 5380:
-  name: "Calamari"
+  name: "イカ"
 5381:
-  name: "Jalea"
+  name: "ハレア"
 5382:
-  name: "Ice Cream"
+  name: "アイスクリーム"
 5383:
-  name: "Herbs"
+  name: "ハーブ"
 5384:
-  name: "Nandu Leather"
+  name: "ダチョウの革"
 5385:
-  name: "Milk"
+  name: "牛乳"
 5386:
-  name: "Orchid"
+  name: "蘭"
 5387:
   name: "Ice Cube"
 5388:
-  name: "Perfumes"
+  name: "香水"
 5389:
-  name: "Costumes"
+  name: "コスチューム"
 5390:
-  name: "Motor"
+  name: "モーター"
 5391:
-  name: "Scooter"
+  name: "スクーター"
 5392:
-  name: "Film Reel"
+  name: "フィルムリール"
 5393:
-  name: "Fire Extinguishers"
+  name: "消火器"
 5394:
-  name: "Police Equipment"
+  name: "警察装備"
 5395:
-  name: "Fans"
+  name: "換気扇"
 5397:
-  name: "Medicine"
+  name: "薬"
 5398:
-  name: "Minerals"
+  name: "鉱物"
 5399:
-  name: "Ammonia"
+  name: "アンモニア"
 5400:
-  name: "Pigments"
+  name: "顔料"
 5401:
-  name: "Nandu Feathers"
+  name: "ダチョウの羽"
 5406:
-  name: "Artista Workforce"
+  name: "アルティスタの労働力"
 5803:
-  name: "Soccer Balls"
+  name: "サッカーボール"
 5830:
-  name: "Cinema"
+  name: "映画館"
 5831:
-  name: "Samba School"
+  name: "サンバスクール"
 6261:
-  name: "Automated Riot Control"
+  name: "自動暴動鎮圧"
 6262:
-  name: "Automated Fire Protection"
+  name: "自動防火"
 6263:
-  name: "Automated Healthcare"
+  name: "自動医療"
 6265:
-  name: "Beach"
+  name: "ビーチ"
 6280:
-  name: "Electric Cables"
+  name: "電線"
 6360:
-  name: "Silver Ore"
+  name: "銀鉱石"
 6600:
-  name: "Mezcal"
+  name: "メスカル"
 24187:
-  name: "Trees"
+  name: "木"
 24320:
-  name: "Herbarium"
+  name: "植物標本"
 24807:
-  name: "Dung"
+  name: "フン"
 24808:
-  name: "Fertiliser"
+  name: "肥料"
 24821:
-  name: "Coke"
+  name: "コークス"
 24824:
-  name: "Chewing Gum"
+  name: "チューインガム"
 24837:
-  name: "Fuel"
+  name: "燃料"
 24846:
-  name: "Silver Amalgam"
+  name: "銀混合物"
 24850:
-  name: "Silver Bars"
+  name: "銀の延べ棒"
 24851:
-  name: "Silver Coins"
+  name: "銀貨"
 24852:
-  name: "Cyanide"
+  name: "シアン化物"
 24863:
   name: "Industrial lubricant "
 25073:
-  name: "Waste Water"
+  name: "廃水"
 25131:
-  name: "Atole"
+  name: "アトーレ"
 25506:
-  name: "Hot Sauce"
+  name: "ホットソース"
 25546:
-  name: "Hacienda"
+  name: "大農園"
 112518:
-  name: "Scrap"
+  name: "スクラップ"
 112520:
-  name: "Nice Scrap"
+  name: "上質なスクラップ"
 112523:
-  name: "Special Scrap"
+  name: "特殊なスクラップ"
 112653:
-  name: "Explorer Workforce"
+  name: "探検家の労働力"
 112654:
-  name: "Technicians Workforce"
+  name: "技術家の労働力"
 112693:
-  name: "Post Office"
+  name: "郵便局"
 112694:
-  name: "Caribou Meat"
+  name: "カリブーの肉"
 112695:
-  name: "Bear Fur"
+  name: "熊の毛皮"
 112696:
-  name: "Seal Skin"
+  name: "アザラシの皮"
 112697:
-  name: "Goose Feathers"
+  name: "ガチョウの羽"
 112698:
-  name: "Huskies"
+  name: "ハスキー"
 112699:
-  name: "Whale Oil"
+  name: "鯨油"
 112700:
-  name: "Parkas"
+  name: "防寒着"
 112701:
-  name: "Sleeping Bags"
+  name: "寝袋"
 112702:
-  name: "Oil Lamps"
+  name: "オイルランプ"
 112703:
-  name: "Husky Sleds"
+  name: "犬ぞり"
 112704:
-  name: "Sleds"
+  name: "そり"
 112705:
-  name: "Pemmican"
+  name: "非常食"
 112706:
-  name: "Arctic Gas"
+  name: "北極ガス"
 112708:
-  name: "Heat"
+  name: "熱"
 114340:
-  name: "Shepherd Workforce"
+  name: "羊飼いの労働力"
 114341:
-  name: "Elder Workforce"
+  name: "長老の労働力"
 114355:
-  name: "Marketplace"
+  name: "マーケット"
 114356:
-  name: "Wanza Timber"
+  name: "ワンザの木板"
 114357:
-  name: "Sanga Cow"
+  name: "サンガ牛"
 114358:
-  name: "Salt"
+  name: "塩"
 114359:
-  name: "Dried Meat"
+  name: "干し肉"
 114361:
-  name: "Musicians' Court"
+  name: "音楽広場"
 114362:
-  name: "Monastery"
+  name: "修道院"
 114364:
-  name: "Hibiscus Petals"
+  name: "ハイビスカスの花びら"
 114365:
-  name: "Linseed"
+  name: "亜麻仁"
 114367:
-  name: "Teff"
+  name: "テフ"
 114368:
-  name: "Indigo Dye"
+  name: "藍の染料"
 114369:
-  name: "Spices"
+  name: "香辛料"
 114370:
-  name: "Beeswax"
+  name: "蜜蝋"
 114371:
-  name: "Goat Milk"
+  name: "ヤギのミルク"
 114390:
-  name: "Hibiscus Tea"
+  name: "ハイビスカスティー"
 114391:
-  name: "Linen"
+  name: "リネン"
 114401:
-  name: "Finery"
+  name: "美服"
 114402:
-  name: "Mud Bricks"
+  name: "泥レンガ"
 114404:
-  name: "Tapestries"
+  name: "タペストリー"
 114408:
-  name: "Spiced Flour"
+  name: "香辛料入り小麦粉"
 114410:
-  name: "Seafood Stew"
+  name: "シーフードシチュー"
 114414:
-  name: "Clay Pipe"
+  name: "陶製のパイプ"
 114425:
-  name: "Radio Tower"
+  name: "ラジオ塔"
 114427:
-  name: "Decorative Cloth"
+  name: "飾り布"
 114428:
-  name: "Leather Boots"
+  name: "革の長靴"
 114429:
   name: "Ammunition"
 114430:
-  name: "Tailored Suits"
+  name: "オーダースーツ"
 114431:
-  name: "Telephones"
+  name: "電話"
 114433:
-  name: "Essential Oil"
+  name: "精油"
 114890:
-  name: "Canteen"
+  name: "食堂"
 115980:
-  name: "Lost Expedition Scrap"
+  name: "行方不明の探検隊のスクラップ"
 117698:
-  name: "Illuminated Script"
+  name: "彩飾された写本"
 117699:
-  name: "Lanterns"
+  name: "ランタン"
 117701:
-  name: "Ornate Candles"
+  name: "華美なキャンドル"
 117702:
-  name: "Paper"
+  name: "紙"
 118724:
-  name: "Ceramics"
+  name: "陶器"
 118728:
-  name: "Lobster"
+  name: "ロブスター"
 119392:
-  name: "Research Points"
+  name: "研究ポイント"
 120008:
-  name: "Wood"
+  name: "丸太"
 120014:
-  name: "後で"
+  name: "ブドウ"
 120016:
-  name: "ランダム設定"
+  name: "シャンパン"
 120020:
-  name: "Market"
+  name: "市場"
 120021:
-  name: "警察装備"
+  name: "石炭"
 120022:
-  name: "換気扇"
+  name: "電気"
 120030:
-  name: "ハーディフ"
+  name: "眼鏡"
 120031:
-  name: "イーストマウス"
+  name: "コーヒー豆"
 120032:
-  name: "ヒルモント"
+  name: "コーヒー"
 120033:
-  name: "カーソーム"
+  name: "揚げバナナ"
 120034:
-  name: "Corn"
+  name: "トウモロコシ"
 120035:
-  name: "ブラクトン"
+  name: "トルティーヤ"
 120036:
-  name: "ダンヨーク"
+  name: "アルパカ生地"
 120037:
-  name: "スウィートホール"
+  name: "山高帽"
 120041:
-  name: "シフィントン"
+  name: "バナナ"
 120042:
-  name: "ヌーボトル"
+  name: "魚油"
 120043:
-  name: "クリップフォード"
+  name: "ポンチョ"
 120044:
-  name: "オールド・アビー"
+  name: "フェルト"
 120050:
-  name: "Chapel"
+  name: "礼拝堂"
 124478:
-  name: "Scholar Workforce"
+  name: "学者の労働力"
 132723:
-  name: "Tourist Customers"
+  name: "観光客の入店数"
 132751:
-  name: "Restaurant"
+  name: "レストラン"
 132754:
-  name: "Bar"
+  name: "バー"
 132755:
-  name: "Café"
+  name: "カフェ"
 132761:
-  name: "The Iron Tower"
+  name: "アイアンタワー"
 133093:
-  name: "Cinnamon"
+  name: "シナモン"
 133095:
-  name: "Coconut Oil"
+  name: "ココナッツオイル"
 133097:
-  name: "Citrus"
+  name: "柑橘類"
 133181:
-  name: "Shampoo"
+  name: "シャンプー"
 133183:
-  name: "Jam"
+  name: "ジャム"
 133185:
-  name: "水の街灯"
+  name: "レモネード"
 133532:
-  name: "Souvenirs"
+  name: "土産物"
 133535:
-  name: "Museum"
+  name: "博物館"
 133536:
-  name: "ヒマワリのブランコ"
+  name: "世界博覧会"
 133573:
-  name: "Variety Theatre"
+  name: "多目的劇場"
 133891:
-  name: "Tourist Mooring"
+  name: "観光停泊地"
 134257:
-  name: "Palace"
+  name: "宮殿"
 134616:
-  name: "花火の台"
+  name: "樟脳"
 134623:
-  name: "Elevators"
+  name: "エレベーター"
 134781:
-  name: "「ワーイ！」（編集長からのコメント）"
+  name: "港湾地区"
 135086:
-  name: "Resin"
+  name: "松脂"
 135087:
-  name: "Cherry Wood"
+  name: "サクラの木"
 135107:
-  name: "Furniture Store"
+  name: "家具店"
 135108:
-  name: "Department Store"
+  name: "デパート"
 135109:
-  name: "Drug Store"
+  name: "ドラッグストア"
 135129:
-  name: "Lacquer"
+  name: "ラッカー"
 135130:
-  name: "Ethanol"
+  name: "エタノール"
 135150:
-  name: "Celluloid"
+  name: "セルロイド"
 135186:
-  name: "Chewing Gum"
+  name: "チューインガム"
 135229:
-  name: "Biscuits"
+  name: "ビスケット"
 135230:
-  name: "Typewriters"
+  name: "タイプライター"
 135231:
-  name: "Toys"
+  name: "おもちゃ"
 135232:
-  name: "Billiard Tables"
+  name: "ビリヤード台"
 135233:
-  name: "Violins"
+  name: "バイオリン"
 135234:
-  name: "Cognac"
+  name: "コニャック"
 135816:
-  name: "Toaster Supply"
+  name: "トースターの供給"
 135876:
-  name: "Crockery Supply"
+  name: "陶器の供給"
 135877:
-  name: "Vaccum Cleaner Supply"
+  name: "電気掃除機の供給"
 135878:
-  name: "Refrigerator Supply"
+  name: "冷蔵庫の供給"
 135879:
-  name: "Briefcase Supply"
+  name: "ブリーフケースの供給"
 135880:
-  name: "Banker's Lamp Supply"
+  name: "バンカーズランプの供給"
 135881:
-  name: "Vanity Screen Supply"
+  name: "パーテーションの供給"
 135882:
-  name: "Writing Desk Supply"
+  name: "書き物机の供給"
 135883:
-  name: "Four-Poster Bed Supply"
+  name: "四柱式ベッドの供給"
 135884:
-  name: "Lounge Seating Supply"
+  name: "ラウンジチェアの供給"
 135885:
-  name: "Toothpaste Supply"
+  name: "歯磨き粉の供給"
 135886:
-  name: "Detergent Supply"
+  name: "洗剤の供給"
 135887:
-  name: "Lipstick Supply"
+  name: "口紅の供給"
 135888:
-  name: "Face Cream Supply"
+  name: "美顔クリームの供給"
 135889:
-  name: "Pomade Supply"
+  name: "ポマードの供給"
 137757:
-  name: "Skyline Tower"
+  name: "スカイラインタワー"
 269751:
-  name: "Fuel"
+  name: "燃料"
 270042:
-  name: "Fuel"
+  name: "燃料"
 601485:
-  name: "Zoo"
+  name: "動物園"
 1010017:
-  name: "Coins"
+  name: "コイン"
 1010052:
-  name: "Farmer Workforce"
+  name: "農家の労働力"
 1010115:
-  name: "Worker Workforce"
+  name: "労働者の労働力"
 1010116:
-  name: "Artisan Workforce"
+  name: "職人の労働力"
 1010117:
-  name: "Engineer Workforce"
+  name: "技師の労働力"
 1010128:
-  name: "Investor Workforce"
+  name: "投資家の労働力"
 1010190:
-  name: "Influence"
+  name: "影響力"
 1010192:
-  name: "Grain"
+  name: "穀物"
 1010193:
-  name: "Beef"
+  name: "牛肉"
 1010194:
-  name: "こんな無意味な虐殺に勝者などいるわけがない…"
+  name: "ホップ"
 1010195:
-  name: "Potatoes"
+  name: "ジャガイモ"
 1010196:
-  name: "Timber"
+  name: "木板"
 1010197:
-  name: "Wool"
+  name: "羊毛"
 1010198:
-  name: "Red Peppers"
+  name: "赤トウガラシ"
 1010199:
-  name: "Ubisoftサーバーに接続中…"
+  name: "豚"
 1010200:
-  name: "Fish"
+  name: "魚"
 1010201:
-  name: "セーブゲーム数"
+  name: "粘土"
 1010202:
-  name: "Reinforced Concrete"
+  name: "鉄筋コンクリート"
 1010203:
-  name: "Soap"
+  name: "石鹸"
 1010204:
-  name: "セーブゲーム容量"
+  name: "真鍮"
 1010205:
-  name: "Bricks"
+  name: "レンガ"
 1010206:
-  name: "Sewing Machines"
+  name: "ミシン"
 1010207:
-  name: "Windows"
+  name: "窓"
 1010208:
-  name: "Light Bulbs"
+  name: "電球"
 1010209:
-  name: "Furs"
+  name: "毛皮"
 1010210:
-  name: "Sails"
+  name: "帆布"
 1010211:
-  name: "Chassis"
+  name: "シャーシ"
 1010213:
-  name: "Bread"
+  name: "パン"
 1010214:
-  name: "Beer"
+  name: "ビール"
 1010215:
-  name: "Goulash"
+  name: "グーラッシュ"
 1010216:
-  name: "外す"
+  name: "シュナップス"
 1010217:
-  name: "Canned Food"
+  name: "缶詰"
 1010218:
-  name: "プリセットを編集"
+  name: "鉄骨材"
 1010219:
-  name: "初回ボーナス"
+  name: "鋼鉄"
 1010221:
-  name: "Weapons"
+  name: "武器"
 1010222:
-  name: "名前"
+  name: "ダイナマイト"
 1010223:
-  name: "プレイ時間"
+  name: "最新武器"
 1010224:
-  name: "サイズ"
+  name: "蒸気モーター"
 1010225:
-  name: "保存日時"
+  name: "蒸気自動車"
 1010226:
-  name: "船の移動"
+  name: "石炭"
 1010227:
-  name: "Iron"
+  name: "鉄"
 1010228:
-  name: "Quartz Sand"
+  name: "けい砂"
 1010229:
-  name: "カメラの速度/傾き"
+  name: "亜鉛"
 1010230:
-  name: "Copper"
+  name: "銅"
 1010231:
-  name: "Cement"
+  name: "セメント"
 1010232:
-  name: "美しい建物"
+  name: "硝石"
 1010233:
-  name: "Gold Ore"
+  name: "金鉱"
 1010234:
-  name: "Tallow"
+  name: "獣脂"
 1010235:
-  name: "Flour"
+  name: "小麦粉"
 1010236:
-  name: "Malt"
+  name: "麦芽"
 1010237:
-  name: "Work Clothes"
+  name: "作業着"
 1010238:
-  name: "ゲーム開始"
+  name: "ソーセージ"
 1010239:
-  name: "スクーター"
+  name: "砂糖"
 1010240:
-  name: "フィルムリール"
+  name: "綿布"
 1010241:
-  name: "Glass"
+  name: "ガラス"
 1010242:
-  name: "Wood Veneers"
+  name: "寄せ木細工"
 1010243:
-  name: "イカ"
+  name: "フィラメント"
 1010245:
-  name: "Penny Farthings"
+  name: "ファージング硬貨"
 1010246:
-  name: "ハレア"
+  name: "懐中時計"
 1010247:
-  name: "アイスクリーム"
+  name: "毛皮のコート"
 1010248:
-  name: "ハーブ"
+  name: "蓄音機"
 1010249:
-  name: "ダチョウの革"
+  name: "金"
 1010250:
-  name: "牛乳"
+  name: "宝石"
 1010251:
-  name: "蘭"
+  name: "さとうきび"
 1010252:
-  name: "Tobacco"
+  name: "タバコ"
 1010253:
-  name: "Cotton"
+  name: "木綿"
 1010254:
-  name: "Ice Cube"
+  name: "ココア"
 1010255:
-  name: "香水"
+  name: "天然ゴム"
 1010256:
-  name: "コスチューム"
+  name: "真珠"
 1010257:
-  name: "Rum"
+  name: "ラム酒"
 1010258:
-  name: "モーター"
+  name: "チョコレート"
 1010259:
-  name: "消火器"
+  name: "葉巻"
 1010348:
-  name: "Boxing Arena"
+  name: "格闘アリーナ"
 1010349:
-  name: "Pub"
+  name: "パブ"
 1010350:
-  name: "Church"
+  name: "教会"
 1010351:
-  name: "School"
+  name: "学校"
 1010352:
-  name: "Variety Theatre"
+  name: "多目的劇場"
 1010353:
-  name: "University"
+  name: "大学"
 1010354:
-  name: "Electricity"
+  name: "電気"
 1010355:
-  name: "ジャガーの顎が閉じるのを感じます…"
+  name: "会員制クラブ"
 1010356:
-  name: "Bank"
+  name: "銀行"
 1010366:
-  name: "ドラグスボルグ"
+  name: "日雇い労働者の労働者"
 1010367:
-  name: "アラセン"
+  name: "労働者の労働力"
 1010566:
-  name: "Oil"
+  name: "石油"

--- a/src/anno_save_analyzer/trade/sessions.py
+++ b/src/anno_save_analyzer/trade/sessions.py
@@ -13,12 +13,17 @@ from .models import GameTitle
 # locale yaml の `session.<title>.<key>` を引いて display 名を得る．
 SESSION_KEYS: dict[GameTitle, tuple[str, ...]] = {
     GameTitle.ANNO_117: ("latium", "albion"),
+    # Anno 1800 は book 1 から DLC を時系列で解放する順に作られる内部 index と
+    # 思っとったが **実セーブで実測したら違った** (書記長報告 2026-04-22)．
+    # FileDB の ``SessionData > BinaryData`` が並ぶ順は「Cape Trelawney, Old World,
+    # Enbesa, New World, Arctic」やった．世界地図の章立て順でも年代順でもない，
+    # Ubisoft 内部の asset ID 順っぽい．実セーブ起点で固定する．
     GameTitle.ANNO_1800: (
-        "old_world",
-        "new_world",
         "cape_trelawney",
-        "arctic",
+        "old_world",
         "enbesa",
+        "new_world",
+        "arctic",
     ),
 }
 

--- a/tests/trade/test_anno1800_smoke.py
+++ b/tests/trade/test_anno1800_smoke.py
@@ -134,19 +134,23 @@ class TestAnno1800RealSampleExtraction:
 
 
 class TestItemDictionaryLoading:
-    """``ItemDictionary.load(ANNO_1800)`` で en/ja の両方が読めること．"""
+    """``ItemDictionary.load(ANNO_1800)`` で en/ja の両方が読めること．
+
+    texts_<lang>.xml は Product GUID 自身を key にして翻訳を持つため，実測で
+    280 Products 全件が en / ja ともヒットする (2026-04-22)．フォールバック
+    ロジックは発動しない想定．
+    """
 
     def test_en_yaml_loads_with_major_products(self) -> None:
         d = ItemDictionary.load(GameTitle.ANNO_1800, locales=("en",))
-        # Key Anno 1800 Products
         assert d[1010566].names.get("en") == "Oil"
         assert d[1010257].names.get("en") == "Rum"
-        # 主要 coin/Money はデータ側で LineID 誤参照があるが embedded_en fallback で救う
         assert d[1010017].names.get("en") == "Coins"
+        assert d[1010240].names.get("en") == "Cotton Fabric"
 
-    def test_ja_yaml_loads_and_falls_back_for_missing_translations(self) -> None:
+    def test_ja_yaml_loads_with_native_translations(self) -> None:
         d = ItemDictionary.load(GameTitle.ANNO_1800, locales=("en", "ja"))
-        # ja で明示翻訳のあるもの
-        assert d[1010240].names.get("ja") == "フィルムリール"
-        # ja 翻訳欠落で embedded_en に degrade する品目 (Money)
-        assert d[1010017].names.get("ja") == "Coins"
+        assert d[1010566].names.get("ja") == "石油"
+        assert d[1010257].names.get("ja") == "ラム酒"
+        assert d[1010017].names.get("ja") == "コイン"
+        assert d[1010240].names.get("ja") == "綿布"

--- a/tests/trade/test_sessions.py
+++ b/tests/trade/test_sessions.py
@@ -17,8 +17,19 @@ class TestSessionKeyFor:
     def test_returns_albion_for_anno117_index_1(self) -> None:
         assert session_key_for(GameTitle.ANNO_117, 1) == "albion"
 
-    def test_returns_old_world_for_anno1800_index_0(self) -> None:
-        assert session_key_for(GameTitle.ANNO_1800, 0) == "old_world"
+    def test_returns_cape_trelawney_for_anno1800_index_0(self) -> None:
+        # 実セーブで観測した順序 (Ubisoft 内部 asset ID 順っぽい)
+        assert session_key_for(GameTitle.ANNO_1800, 0) == "cape_trelawney"
+
+    def test_anno1800_full_order(self) -> None:
+        # 書記長 2026-04-22 報告で修正した順序を固定
+        assert SESSION_KEYS[GameTitle.ANNO_1800] == (
+            "cape_trelawney",
+            "old_world",
+            "enbesa",
+            "new_world",
+            "arctic",
+        )
 
     def test_returns_none_for_out_of_range_index(self) -> None:
         assert session_key_for(GameTitle.ANNO_117, 99) is None
@@ -31,8 +42,9 @@ class TestSessionLocaleKey:
     def test_anno117_latium(self) -> None:
         assert session_locale_key(GameTitle.ANNO_117, 0) == "session.anno117.latium"
 
-    def test_anno1800_enbesa(self) -> None:
-        assert session_locale_key(GameTitle.ANNO_1800, 4) == "session.anno1800.enbesa"
+    def test_anno1800_arctic_at_index_4(self) -> None:
+        # 実セーブ起点順序では末尾は Arctic
+        assert session_locale_key(GameTitle.ANNO_1800, 4) == "session.anno1800.arctic"
 
     def test_unknown_index_falls_back_to_unknown(self) -> None:
         assert session_locale_key(GameTitle.ANNO_117, 99) == "session.unknown"


### PR DESCRIPTION
## Summary
書記長報告 2026-04-22 の 2 件を同時に直す．

### 1. SESSION_KEYS の順序ズレ
Tool が「旧世界」と表示しとった session に実際は Cape Trelawney のデータが入っとった等，全 5 session 中 4 つで label が間違っとった．DLC リリース順で並んどると想定して SESSION_KEYS を組んだんやが，実セーブの ``SessionData > BinaryData`` の並びは別の順序 (Ubisoft 内部 asset ID 順っぽい)．実測結果で固定：

| index | 旧 | 新 (実測) |
|---|---|---|
| 0 | old_world | **cape_trelawney** |
| 1 | new_world | **old_world** |
| 2 | cape_trelawney | **enbesa** |
| 3 | arctic | **new_world** |
| 4 | enbesa | **arctic** |

### 2. ja 翻訳が英語まま
原因: items 生成器が ``Values/Text/LineID`` 経由で ``texts_<lang>.xml`` を引いとった．**LineID は Ubisoft 側のデータで誤参照が多数**：

| guid | 旧 (LineID 経由) | 実際 (GUID 直参照) |
|---|---|---|
| 1010017 | POCKET WATCHES RUN OUT! / 懐中時計不足！ | Coins / コイン |
| 1010226 | Move Ship / 船の移動 | Coal / 石炭 |
| 1010240 | Film Reel / フィルムリール | Cotton Fabric / 綿布 |
| 120032 | Hillmont | Coffee / コーヒー |
| 1010255 | Perfumes | Rubber / 天然ゴム |
| 1010259 | Fire Extinguishers | Cigars / 葉巻 |

実測: ``texts_<lang>.xml`` は Product GUID 自身 を key に翻訳を持っとる (280/280 Products 全件 en/ja ヒット)．LineID + embedded_en + heuristic の 3 段スタックを削除して GUID 直参照 1 本に簡素化．

### 効果 (``--locale ja`` での trade summary top15)
```
guid=1010566  name='石油'                 sold=27,896
guid=1010257  name='ラム酒'                sold=13,870
guid=535      name='普通郵便'               sold=9,832
guid=120032   name='コーヒー'               sold=7,968
guid=1010226  name='石炭'                 sold=6,698
guid=1010227  name='鉄'                  sold=6,695
guid=1010240  name='綿布'                 sold=5,466
guid=1010207  name='窓'                  sold=4,501
guid=1010255  name='天然ゴム'               sold=3,704
guid=1010228  name='けい砂'                sold=3,459
guid=1010206  name='ミシン'                sold=3,301
guid=1010238  name='ソーセージ'              sold=2,669
guid=1010202  name='鉄筋コンクリート'           sold=2,547
```

### カバレッジ
- 491 passed, branch coverage 98.63%

## Test plan
- [ ] CI 緑
- [ ] 書記長が TUI を ja で開いたとき session ラベルと商品名が両方合っとる