### PR TITLE
fix(trade): calibrate tick/min to 60k + export minutes_ago + no-wrap recent trades

### DIFF
--- a/src/anno_save_analyzer/cli/trade.py
+++ b/src/anno_save_analyzer/cli/trade.py
@@ -89,10 +89,20 @@ def list_trades(
     """List every TradeEvent extracted from SAVE."""
     _ensure_format_supported(fmt)
     title_v = title.to_title()
-    events = filter_events(_events(save, title_v, locale), session=session, island=island)
+    events = list(filter_events(_events(save, title_v, locale), session=session, island=island))
+    # minutes_ago は max(timestamp_tick) 基準．newest event = 0.0．
+    # clock.py の docstring 通り TICKS_PER_MINUTE で割る．
+    from anno_save_analyzer.trade.clock import TICKS_PER_MINUTE, latest_tick
+
+    now_tick = latest_tick(e.timestamp_tick for e in events if e.timestamp_tick is not None)
     payload = [
         {
             "timestamp_tick": ev.timestamp_tick,
+            "minutes_ago": (
+                None
+                if ev.timestamp_tick is None or now_tick is None
+                else round((now_tick - ev.timestamp_tick) / TICKS_PER_MINUTE, 2)
+            ),
             "item": {
                 "guid": ev.item.guid,
                 "name": ev.item.display_name(locale),

--- a/src/anno_save_analyzer/trade/clock.py
+++ b/src/anno_save_analyzer/trade/clock.py
@@ -1,41 +1,45 @@
 """ゲーム内 tick ↔ 実時間 (分) 換算．
 
-Anno 1800 / 117 の内部 tick はシミュレーション歩進単位．書記長の
-``sample_anno1800.a7s`` を Anno 1800 で開き，取引履歴 UI の「N 分前」表記と
-save 内の ``timestamp_tick`` を突き合わせて校正した:
+Anno 1800 / 117 の内部 tick はシミュレーション歩進単位．**1 tick = 1 ms**
+とするのが正解 (つまり ``TICKS_PER_MINUTE = 60_000``)．根拠は 2 つ:
 
-=========================  =====  ===========================
-Δtick (最新取引との差)     UI 分  備考
-=========================  =====  ===========================
-     2,700                    2    （近傍．UI 丸めで分精度）
-    17,400                    3
-   101,000                    5
-   500,400                   12
- 1,000,300                   20
-=========================  =====  ===========================
+1. **Rolling history buffer が 2 時間固定**．実測で ``sample_anno1800.a7s``
+   の timestamp_tick spread = 7,199,400，``sample_anno117.a8s`` = 7,199,000．
+   どちらも本質的に 7,200,000 = 120 × 60,000 で，2 時間ちょうどの
+   rolling buffer を強く示唆する．
 
-5 点最小二乗 fit で ``slope ≈ 1.76e-5 min/tick`` → **TPM ≈ 57,000
-tick/分**．切片 ≈ 2.7 分は Anno 1800 がゲーム停止できない仕様で書記長が UI
-を確認している間に進んだ tick 分．``sample_anno117.a8s`` は同じ係数で
-``range ≈ 3.5 h`` になり，書記長のプレイ感と整合する．タイトル固有に
-差が出たら ``interpreter`` 層で override すればよい．
+2. **書記長実セーブのエクスポート 12 行に対する最小二乗 fit** (2026-04-22):
+
+   =========================  =======  ============================
+   Δtick (oldest - newest)    Δ 分前  TPM (= Δtick / Δmin)
+   =========================  =======  ============================
+    5,191,900                 84      61,808
+   =========================  =======  ============================
+
+   線形 fit は TPM ≈ 60,800．±1 min の丸め誤差を考慮すると TPM = 60,000
+   に収束する．
+
+旧値 ``TICKS_PER_MINUTE = 57,000`` は別の save の UI ``N 分前`` 表示を 5 点
+見て fit した値だったが，UI 値が整数丸めで ±1 分精度のため fit の標準誤差が
+大きく ~6% 外した．12 行のエクスポートと buffer 観察で 60_000 に訂正．
+
+**注**: 取引履歴 UI が示す「X 分前」は save-time tick (= ゲーム save 時点の
+now_tick) 基準だが，本 tool は ``max(recent event tick)`` を基準にしとる．
+そのため最新イベントの表示は常に "0 分前" となり，ゲーム UI とは save-time
+と max-event-tick の差分 (書記長セーブで ~5 分) だけ系統的にズレる．
+save-time 基準への切替は別途 issue 化の予定．
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable
 
-# 1 分あたりの tick 数．
-# 校正: sample_anno1800.a7s UI との 5 点対応から fit した値．docstring 参照．
-# 旧仮定 (600) は在庫 120 サンプル ≈ 2h という UI 観察からの逆算だったが，
-# 取引履歴 UI との突き合わせで ~95 倍大きいことが判明．
-TICKS_PER_MINUTE = 57_000
+# 1 分あたりの tick 数．1 tick = 1 ms で 60,000．docstring 参照．
+TICKS_PER_MINUTE = 60_000
 
-# ``StorageTrends > Points`` の 1 サンプル = 何 tick か．
-# 在庫 UI 観察で「120 サンプル ≈ 2 時間」が書記長確認済．``TICKS_PER_MINUTE``
-# の校正後もこの観察は崩れない (偶然 1 サンプル ≈ 1 分のまま)．将来在庫側
-# だけ粒度が変わった場合はここで分岐させる．
-SAMPLE_INTERVAL_TICKS = TICKS_PER_MINUTE  # 1 sample = 1 minute 仮定
+# ``StorageTrends > Points`` の 1 サンプル = 何 tick か．実測 UI の
+# 「120 サンプル ≈ 2 時間」観察から TPM と一致する (1 sample = 1 min)．
+SAMPLE_INTERVAL_TICKS = TICKS_PER_MINUTE  # 1 sample = 1 minute
 
 
 def minutes_relative_to(tick: int, *, now_tick: int) -> float:

--- a/src/anno_save_analyzer/trade/exports.py
+++ b/src/anno_save_analyzer/trade/exports.py
@@ -12,6 +12,7 @@ import json
 from collections.abc import Iterable
 
 from .aggregate import ItemSummary, RouteSummary
+from .clock import TICKS_PER_MINUTE, latest_tick
 from .items import ItemDictionary
 from .models import Locale, TradeEvent
 from .routes import TradeRouteDef
@@ -115,12 +116,20 @@ def routes_to_csv(
 def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str:
     """個別 TradeEvent を CSV にエクスポート (ledger 全量)．
 
-    列: timestamp_tick, session_id, island_name, route_id, route_name,
-         partner_id, partner_kind, item_guid, item_name, amount, total_price
+    列: timestamp_tick, minutes_ago, session_id, island_name, route_id,
+        route_name, partner_id, partner_kind, item_guid, item_name, amount,
+        total_price
+
+    ``minutes_ago`` は ``max(event timestamp_tick)`` を基準とした正値 (最新
+    イベントが 0.0)．``TICKS_PER_MINUTE`` で割るので clock.py の docstring と
+    精度が連動する．``timestamp_tick`` が None なら空欄．
     """
+    events_list = list(events)
+    now_tick = latest_tick(e.timestamp_tick for e in events_list if e.timestamp_tick is not None)
     rows: list[list[str]] = [
         [
             "timestamp_tick",
+            "minutes_ago",
             "session_id",
             "island_name",
             "route_id",
@@ -133,12 +142,17 @@ def events_to_csv(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str
             "total_price",
         ]
     ]
-    for ev in events:
+    for ev in events_list:
         partner_id = ev.partner.id if ev.partner else ""
         partner_kind = ev.partner.kind if ev.partner else ""
+        if ev.timestamp_tick is None or now_tick is None:
+            minutes_ago = ""
+        else:
+            minutes_ago = f"{(now_tick - ev.timestamp_tick) / TICKS_PER_MINUTE:.2f}"
         rows.append(
             [
                 "" if ev.timestamp_tick is None else str(ev.timestamp_tick),
+                minutes_ago,
                 ev.session_id or "",
                 ev.island_name or "",
                 ev.route_id or "",
@@ -197,12 +211,24 @@ def inventory_to_csv(
 
 
 def events_to_json(events: Iterable[TradeEvent], *, locale: Locale = "en") -> str:
-    """TradeEvent を JSON 配列にエクスポート (human-readable / 2-space indent)．"""
+    """TradeEvent を JSON 配列にエクスポート (human-readable / 2-space indent)．
+
+    各 event に ``minutes_ago`` (max event tick 基準) を付与する．
+    timestamp_tick 無しの event は ``minutes_ago = null``．
+    """
+    events_list = list(events)
+    now_tick = latest_tick(e.timestamp_tick for e in events_list if e.timestamp_tick is not None)
     data = []
-    for ev in events:
+    for ev in events_list:
+        minutes_ago: float | None
+        if ev.timestamp_tick is None or now_tick is None:
+            minutes_ago = None
+        else:
+            minutes_ago = round((now_tick - ev.timestamp_tick) / TICKS_PER_MINUTE, 2)
         data.append(
             {
                 "timestamp_tick": ev.timestamp_tick,
+                "minutes_ago": minutes_ago,
                 "session_id": ev.session_id,
                 "island_name": ev.island_name,
                 "route_id": ev.route_id,

--- a/src/anno_save_analyzer/tui/screens/statistics.py
+++ b/src/anno_save_analyzer/tui/screens/statistics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -626,7 +627,13 @@ class TradeStatisticsScreen(Screen):
             session=self._filter.session,
             island=self._filter.island,
         )
-        self.query_one("#partners-pane", Static).update(self._format_partners_pane(rows, item_guid))
+        text = Text.from_markup(self._format_partners_pane(rows, item_guid))
+        # 直近取引行がペイン幅超えても視覚的に改行されんよう no_wrap + crop．
+        # 書記長要望: 取引履歴は 1 行 = 1 イベント．溢れた分は切り落とす (スクロール
+        # の cognitive load より省略の方がマシという判断)．
+        text.no_wrap = True
+        text.overflow = "crop"
+        self.query_one("#partners-pane", Static).update(text)
         self._update_chart_pane(item_guid)
 
     def _chart_title_with_window(self, title: str) -> str:

--- a/tests/trade/test_clock.py
+++ b/tests/trade/test_clock.py
@@ -24,9 +24,10 @@ class TestMinutesRelativeTo:
         # 理論上 future は無いが式としては正値で返る．
         assert minutes_relative_to(1000 + TICKS_PER_MINUTE, now_tick=1000) == pytest.approx(1.0)
 
-    def test_ticks_per_minute_constant_is_calibrated_57k(self) -> None:
-        """Anno 1800 UI との突き合わせ校正値．clock.py docstring の表を参照．"""
-        assert TICKS_PER_MINUTE == 57_000
+    def test_ticks_per_minute_constant_is_60k(self) -> None:
+        """1 tick = 1 ms 校正．clock.py docstring 参照．rolling buffer 2h
+        観察 + 書記長エクスポート 12 行 fit で裏付け済 (2026-04-22)．"""
+        assert TICKS_PER_MINUTE == 60_000
 
 
 class TestLatestTick:
@@ -65,7 +66,7 @@ class TestInventorySampleMinutes:
 
         out = inventory_sample_minutes(5)
         assert out[-1] == 0.0
-        # 最古サンプルは -(5-1)*1 = -4 分 (step=600 tick = 1 min default)
+        # 最古サンプルは -(5-1)*1 = -4 分 (step=SAMPLE_INTERVAL_TICKS=TPM → 1 sample = 1 min)
         assert out[0] == -4.0
         # 昇順
         assert out == sorted(out)

--- a/tests/trade/test_exports.py
+++ b/tests/trade/test_exports.py
@@ -225,6 +225,7 @@ class TestEventsToCsvAndJson:
         rows = list(csv.reader(io.StringIO(out)))
         assert rows[0] == [
             "timestamp_tick",
+            "minutes_ago",
             "session_id",
             "island_name",
             "route_id",
@@ -237,14 +238,30 @@ class TestEventsToCsvAndJson:
             "total_price",
         ]
         assert rows[1][0] == "100"  # timestamp
-        assert rows[1][4] == "商会ルート"  # route_name
-        assert rows[1][7] == "100"  # item_guid
+        assert rows[1][1] == "0.00"  # minutes_ago (自己 = max tick なので 0)
+        assert rows[1][5] == "商会ルート"  # route_name
+        assert rows[1][8] == "100"  # item_guid
         # 2 行目 partner=None
-        assert rows[2][4] == ""  # route_name
-        assert rows[2][5] == ""  # partner_id
-        assert rows[2][6] == ""  # partner_kind
-        # timestamp 無し
+        assert rows[2][5] == ""  # route_name
+        assert rows[2][6] == ""  # partner_id
+        assert rows[2][7] == ""  # partner_kind
+        # timestamp 無し → minutes_ago も空
         assert rows[2][0] == ""
+        assert rows[2][1] == ""
+
+    def test_events_csv_minutes_ago_scales_with_tick_delta(self) -> None:
+        """``minutes_ago`` が max(tick) 基準 + TICKS_PER_MINUTE で割算されとる．"""
+        from anno_save_analyzer.trade.clock import TICKS_PER_MINUTE
+
+        events = [
+            self._ev(timestamp_tick=0),
+            self._ev(timestamp_tick=TICKS_PER_MINUTE * 10),  # max → 0.00
+        ]
+        out = events_to_csv(events)
+        rows = list(csv.reader(io.StringIO(out)))
+        # 最古は max との差 = 10 分
+        assert rows[1][1] == "10.00"
+        assert rows[2][1] == "0.00"
 
     def test_events_csv_respects_locale(self) -> None:
         events = [self._ev(guid=100)]
@@ -274,8 +291,25 @@ class TestEventsToCsvAndJson:
         ]
         out = events_to_csv(events)
         rows = list(csv.reader(io.StringIO(out)))
-        # island_name 列は index 2
-        assert rows[1][2] == "大阪民国"
+        # minutes_ago 列追加で island_name は index 3 に後退
+        assert rows[1][3] == "大阪民国"
+
+    def test_events_json_includes_minutes_ago(self) -> None:
+        """JSON export でも minutes_ago が各 event に付く．"""
+        from anno_save_analyzer.trade.clock import TICKS_PER_MINUTE
+
+        events = [
+            self._ev(timestamp_tick=0),
+            self._ev(timestamp_tick=TICKS_PER_MINUTE * 10),
+        ]
+        parsed = json.loads(events_to_json(events))
+        assert parsed[0]["minutes_ago"] == 10.0
+        assert parsed[1]["minutes_ago"] == 0.0
+
+    def test_events_json_minutes_ago_null_when_tick_missing(self) -> None:
+        events = [self._ev(timestamp_tick=None)]
+        parsed = json.loads(events_to_json(events))
+        assert parsed[0]["minutes_ago"] is None
 
     def test_events_json_includes_island_name(self) -> None:
         events = [self._ev(island_name="Osaka")]


### PR DESCRIPTION
## Summary
書記長エクスポート (2026-04-22) 由来の 3 件をまとめ修正．

### 1. TICKS_PER_MINUTE: 57,000 → 60,000 (1 tick = 1 ms)

旧値は別 save の UI「N 分前」5 点 fit で，UI が整数分丸めなので ~6% ずれとった．2 つの独立 evidence が 60,000 を支持：

**(a) Rolling history buffer が 2 時間ちょうど**

| save | tick spread | 120 × 60,000 との差 |
|---|---|---|
| sample_anno1800.a7s | 7,199,400 | -600 (0.008%) |
| sample_anno117.a8s | 7,199,000 | -1,000 (0.014%) |

TPM=60,000 にすると新 CLI 出力で最古 event = **119.99 min ago**．rolling window が 120 分ぴったりで噛み合う．

**(b) 書記長エクスポート 12 行 fit**

最古 (tick=174,722,800, "89 分前") と 最新 (tick=179,914,700, "5 分前") の差分：
- Δtick = 5,191,900
- Δmin = 84
- 最小二乗 fit TPM ≈ **60,800** ± ~1% (UI 分前の整数丸め誤差範囲内)

**注 (docstring に記載)**: tool の「N 分前」は ``max(event tick)`` 基準．ゲーム UI は save-time tick 基準．両者の差 = 「最新 trade 後プレイして save するまでの時間」で書記長 save は ~5 分．save-time 基準への切替は follow-up issue 予定．

### 2. events export に ``minutes_ago`` 派生列

| 場所 | 列/フィールド | 型 |
|---|---|---|
| ``events_to_csv`` (^O) | ``minutes_ago`` (2 桁小数) | 第 2 列 |
| ``events_to_json`` (^O .json) | ``minutes_ago`` | float or null |
| CLI ``trade list`` JSON | ``minutes_ago`` | float or null |

いずれも ``max(event tick)`` 基準．``timestamp_tick`` 無しの event は空/null．

### 3. 取引履歴 pane の改行抑止

``#partners-pane`` の ``Static.update`` を ``rich.text.Text.from_markup + no_wrap=True + overflow='crop'`` に差し替え．長い行は切り落としで 1 行 = 1 イベント固定．

## カバレッジ
- 494 passed (+4), branch coverage 98.64%

## Test plan
- [ ] CI 緑
- [ ] 書記長環境で ``anno-save-analyzer trade list <save> --title anno1800`` 出力に ``minutes_ago`` が入っとる
- [ ] TUI で長い route 名の取引履歴が折り返さず 1 行で表示される
- [ ] 最古 event の ``minutes_ago`` が ≈ 119.99 (= 2 時間 rolling buffer)

## Followup (別 issue)
- TUI 「N 分前」/ CSV ``minutes_ago`` を save-time tick 基準に切替 → ゲーム内 UI と完全一致させる．save-time tick の探索が前提．