### PR TITLE
fix(storage): extract Anno 1800 StorageTrends (relaxed capacity/size)

### DIFF
--- a/src/anno_save_analyzer/trade/storage.py
+++ b/src/anno_save_analyzer/trade/storage.py
@@ -1,8 +1,7 @@
 """島ごとの在庫時系列 (StorageTrends) 抽出．
 
-Anno 117 の内側 Session DOM には ``AreaInfo > <1> > AreaEconomy >
-StorageTrends`` 階層で **物資ごとの 120 サンプル固定 ring buffer** が保存されて
-いる．本モジュールは
+内側 Session DOM の ``AreaInfo > <1> > AreaEconomy > StorageTrends`` 階層から
+物資ごとの在庫履歴を取り出す．本モジュールは
 
 1. 生 FileDB bytes から ``IslandStorageTrend`` Pydantic model を抽出
 2. ``latest`` / ``peak`` / ``mean`` / ``slope`` 等の derived プロパティを提供
@@ -12,6 +11,7 @@ StorageTrends`` 階層で **物資ごとの 120 サンプル固定 ring buffer**
 
 ## DOM 構造 (実測)
 
+### Anno 117 (sample_anno117.a8s)
 ```
 AreaInfo > <1> (player island, CityName を持つ)
     └─ AreaEconomy
@@ -26,8 +26,27 @@ AreaInfo > <1> (player island, CityName を持つ)
                         └─ A <32768> × 120 (i32 各サンプル値．ring buffer)
 ```
 
-書記長の sample_anno117.a8s で 13 player islands × 110 unique GUIDs = 1,430
-trend rows を検証済．``Points`` は shift register で ``[-1]`` = 最新サンプル．
+1800 と違って `capacity` / `size` named attrib + 120 samples の full ring
+buffer．13 player islands × 110 unique GUIDs = 1,430 trend rows を検証済．
+``Points`` は shift register で ``[-1]`` = 最新サンプル．
+
+### Anno 1800 (sample_anno1800.a7s)
+```
+AreaInfo > <1> (player island, CityName を持つ)
+    └─ AreaEconomy
+        └─ StorageTrends
+            └─ <ProductGUID> (anonymous attrib, i32)
+                └─ <1>
+                    ├─ A LastPointTime: i64
+                    ├─ A Estimation: i32
+                    └─ T Points
+                        └─ A <32768> × 2 (i32．named attrib 無し．実質 [現在値, 前回値])
+```
+
+**Anno 1800 は 2 サンプルしか保存してない**．120 サンプル時系列じゃなくてデルタ
+ペア．latest / peak / slope は成立するが mean はほぼ意味なし，sparkline は
+2 文字だけ．完全な chart は描けん．``capacity`` / ``size`` named attrib が
+無いので loader 側で ``len(samples)`` にフォールバックして yield する．
 """
 
 from __future__ import annotations
@@ -246,21 +265,22 @@ def _iter_trends(inner: bytes, version, section: TagSection) -> Iterator[IslandS
         if in_points_depth is not None and closing_depth == in_points_depth:
             in_points_depth = None
         if in_trend_entry_depth is not None and closing_depth == in_trend_entry_depth:
-            # trend entry close: プレイヤー島 (city_name) かつ GUID 既知なら yield
-            if (
-                city_name
-                and current_guid is not None
-                and current_points_capacity is not None
-                and current_points_size is not None
-            ):
+            # trend entry close: プレイヤー島 (city_name) かつ GUID 既知かつ
+            # サンプルが 1 つ以上あれば yield．Anno 1800 は capacity / size
+            # named attrib を持たず 2 サンプルだけ残す形式なので，その場合は
+            # ``len(samples)`` で補完する (117 の 120 サンプル固定も同じ式で一致)．
+            if city_name and current_guid is not None and current_samples:
+                n = len(current_samples)
                 yield IslandStorageTrend(
                     island_name=city_name,
                     product_guid=current_guid,
                     last_point_tick=current_last_point,
                     estimation=current_estimation,
                     points=PointSeries(
-                        capacity=current_points_capacity,
-                        size=current_points_size,
+                        capacity=current_points_capacity
+                        if current_points_capacity is not None
+                        else n,
+                        size=current_points_size if current_points_size is not None else n,
                         samples=tuple(current_samples),
                     ),
                 )

--- a/tests/trade/test_storage.py
+++ b/tests/trade/test_storage.py
@@ -24,10 +24,14 @@ def _trend_entry(
     samples: list[int],
     last_point_tick: int | None = 144380000,
     estimation: int | None = 0,
-    capacity: int = 120,
-    size: int = 120,
+    capacity: int | None = 120,
+    size: int | None = 120,
 ) -> list[Event]:
-    """StorageTrends 直下の (anon attrib + <1>) ペアを組む．"""
+    """StorageTrends 直下の (anon attrib + <1>) ペアを組む．
+
+    ``capacity`` / ``size`` が ``None`` の場合は named attrib を省く．
+    Anno 1800 の 2 サンプル形式を再現する用途．
+    """
     out: list[Event] = [
         ("A", 0x8FFF, struct.pack("<i", product_guid)),  # anonymous ProductGUID
         ("T", 1),  # trend entry <1>
@@ -37,8 +41,10 @@ def _trend_entry(
     if estimation is not None:
         out.append(("A", 0x8002, struct.pack("<i", estimation)))
     out.append(("T", 2))  # Points
-    out.append(("A", 0x8003, struct.pack("<q", capacity)))
-    out.append(("A", 0x8004, struct.pack("<q", size)))
+    if capacity is not None:
+        out.append(("A", 0x8003, struct.pack("<q", capacity)))
+    if size is not None:
+        out.append(("A", 0x8004, struct.pack("<q", size)))
     for v in samples:
         out.append(("A", 0x8FFF, struct.pack("<i", v)))  # anonymous sample
     out.append(("X",))  # close Points
@@ -139,6 +145,82 @@ class TestNpcIslandFilter:
         trends = list_storage_trends(inner)
         assert len(trends) == 1
         assert trends[0].island_name == "大阪民国"
+
+
+class TestAnno1800Schema:
+    """Anno 1800 は Points に capacity/size named attrib を持たず anonymous
+    i32 × 2 だけを残す schema．``len(samples)`` でフォールバックして yield
+    される必要がある (117 の full time-series と統一 API)．
+    """
+
+    def test_yields_trend_when_capacity_size_missing(self) -> None:
+        """capacity/size 欠落でも samples があれば trend を yield．"""
+        inner = _build_storage_fixture(
+            islands=[
+                # Anno 1800 の実形式: 2 サンプルだけ + capacity/size 省略
+                (
+                    "レニングラード",
+                    [
+                        (1010566, [186, 185]),  # delta: 1 減った
+                        (535, [23, 2]),  # Local Mail 大量消費直後
+                    ],
+                ),
+            ],
+        )
+        # _trend_entry デフォルトを Anno 1800 形式にオーバーライド
+        tags = {2: "Points", 3: "StorageTrends", 4: "AreaEconomy", 5: "AreaInfo"}
+        attribs = {0x8001: "LastPointTime", 0x8002: "Estimation", 0x8005: "CityName"}
+        events: list[Event] = [
+            ("T", 5),
+            ("T", 1),  # AreaInfo > <1>
+            ("A", 0x8005, "レニングラード".encode("utf-16-le")),
+            ("T", 4),
+            ("T", 3),
+            *_trend_entry(product_guid=1010566, samples=[186, 185], capacity=None, size=None),
+            *_trend_entry(product_guid=535, samples=[23, 2], capacity=None, size=None),
+            ("X",),
+            ("X",),
+            ("X",),
+            ("X",),
+        ]
+        inner = minimal_v3(tags=tags, attribs=attribs, events=events)
+        trends = list_storage_trends(inner)
+        assert len(trends) == 2
+        t0 = next(t for t in trends if t.product_guid == 1010566)
+        assert t0.points.samples == (186, 185)
+        # capacity/size は len(samples) にフォールバック
+        assert t0.points.capacity == 2
+        assert t0.points.size == 2
+        # latest は最新サンプル = samples[-1] = 185
+        assert t0.latest == 185
+        assert t0.peak == 186
+        # 2 点 slope: (n*sum_xy - sum_x*sum_y) / (n*sum_xx - sum_x^2)
+        # = (2*185 - 1*(186+185)) / (2*1 - 1) = (370-371)/1 = -1
+        assert t0.points.slope == -1.0
+
+    def test_empty_samples_still_rejected(self) -> None:
+        """samples 0 個 (なにも attrib 入っとらん Points) は yield されない．
+        fallback 条件 ``current_samples`` truthy check で弾かれる．"""
+        tags = {2: "Points", 3: "StorageTrends", 4: "AreaEconomy", 5: "AreaInfo"}
+        attribs = {0x8005: "CityName"}
+        events: list[Event] = [
+            ("T", 5),
+            ("T", 1),
+            ("A", 0x8005, "X".encode("utf-16-le")),
+            ("T", 4),
+            ("T", 3),
+            ("A", 0x8FFF, struct.pack("<i", 42)),  # ProductGUID anon
+            ("T", 1),  # trend entry <1>
+            ("T", 2),  # Points (empty)
+            ("X",),
+            ("X",),
+            ("X",),  # StorageTrends
+            ("X",),  # AreaEconomy
+            ("X",),  # AreaInfo > <1>
+            ("X",),  # AreaInfo
+        ]
+        inner = minimal_v3(tags=tags, attribs=attribs, events=events)
+        assert list_storage_trends(inner) == ()
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## Summary
書記長報告: Anno 1800 で在庫推移タブが空白．調査の結果，DOM schema が違うことが判明．

## 原因

| | Anno 117 | Anno 1800 |
|---|---|---|
| ``Points > capacity`` named attrib | ✅ 120 | ❌ 無し |
| ``Points > size`` named attrib | ✅ 120 | ❌ 無し |
| ``Points`` 配下 anonymous i32 | 120 サンプル ring buffer | **2 サンプル** (実質 ``[現在値, 前回値]``) |

``_iter_trends`` が ``capacity`` / ``size`` 必須だったため Anno 1800 では全 trend が落ちとった．

## 修正
``capacity`` / ``size`` 欠落時は ``len(samples)`` にフォールバック．yield 条件を「city_name + GUID + samples 1 個以上」に緩和．117 は挙動変更なし．

## 効果 (実セーブ)

| save | before | after |
|---|---|---|
| sample_anno117.a8s | 1,430 trends | 1,430 trends (no change) |
| sample_anno1800.a7s | **0 trends** | **2,884 trends** (14 islands × ~206 products) |

latest / peak / slope は 2 サンプルでも有効．mean / sparkline / chart は 2 点だけなので degenerate やけど inventory タブ自体は populate される．

## Followup (可能なら別 issue)
Anno 1800 の save には 120 サンプル時系列が**存在せん**．ゲーム内 UI の在庫推移グラフはどこかから別経路で描いとる (おそらくメモリ上のみ)．複数セーブの diff で時系列を合成する路線が v0.4+ roadmap の候補．

## カバレッジ
- 496 passed (+2 in TestAnno1800Schema), branch coverage 98.64%

## Test plan
- [ ] CI 緑
- [ ] 書記長環境で ``anno-save-analyzer tui sample.a7s --title anno1800`` 叩いて Inventory タブに島が並んで行選択で chart が 2 点折れ線表示される
- [ ] Anno 117 で従来通り 120 点 sparkline / chart が出る (regression check)