### PR TITLE
feat: HTML dashboard export + runway/balance analysis + auto title infer

### DIFF
--- a/src/anno_save_analyzer/cli/_title.py
+++ b/src/anno_save_analyzer/cli/_title.py
@@ -1,0 +1,14 @@
+"""CLI 向けの GameTitle 解決 helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from anno_save_analyzer.trade.models import GameTitle
+
+
+def resolve_title(save: Path, explicit: GameTitle | None) -> GameTitle:
+    """明示指定があればそれを使い，無ければ save 拡張子から推定する．"""
+    if explicit is not None:
+        return explicit
+    return GameTitle.from_save_path(save)

--- a/src/anno_save_analyzer/cli/trade.py
+++ b/src/anno_save_analyzer/cli/trade.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 import typer
 
+from anno_save_analyzer.cli._title import resolve_title
 from anno_save_analyzer.trade import (
     GameTitle,
     ItemDictionary,
@@ -31,16 +32,6 @@ class GameTitleArg(StrEnum):
 
     def to_title(self) -> GameTitle:
         return GameTitle(self.value)
-
-
-def _resolve_title(save: Path, title: GameTitleArg | None) -> GameTitle:
-    """``--title`` 明示指定があればそれを使い，無ければ拡張子から推定．
-
-    ``.a7s`` → Anno 1800 / ``.a8s`` → Anno 117．判別不能なら ValueError．
-    """
-    if title is not None:
-        return title.to_title()
-    return GameTitle.from_save_path(save)
 
 
 class SummaryAxis(StrEnum):
@@ -101,7 +92,7 @@ def list_trades(
 ) -> None:
     """List every TradeEvent extracted from SAVE."""
     _ensure_format_supported(fmt)
-    title_v = _resolve_title(save, title)
+    title_v = resolve_title(save, title.to_title() if title is not None else None)
     events = list(filter_events(_events(save, title_v, locale), session=session, island=island))
     # minutes_ago は max(timestamp_tick) 基準．newest event = 0.0．
     # clock.py の docstring 通り TICKS_PER_MINUTE で割る．
@@ -165,7 +156,7 @@ def summary(
 ) -> None:
     """Summarise trades by item or by route."""
     _ensure_format_supported(fmt)
-    title_v = _resolve_title(save, title)
+    title_v = resolve_title(save, title.to_title() if title is not None else None)
     events = _events(save, title_v, locale)
     if by is SummaryAxis.ITEM:
         item_rows = by_item(events, session=session, island=island)
@@ -235,7 +226,7 @@ def diff(
     """Diff trade activity between BEFORE and AFTER save files."""
     _ensure_format_supported(fmt)
     # diff には save がないので before で推定 (前後とも同じゲームという前提)．
-    title_v = _resolve_title(before, title)
+    title_v = resolve_title(before, title.to_title() if title is not None else None)
     before_events = list(_events(before, title_v, locale))
     after_events = list(_events(after, title_v, locale))
     if by is SummaryAxis.ITEM:

--- a/src/anno_save_analyzer/cli/trade.py
+++ b/src/anno_save_analyzer/cli/trade.py
@@ -33,6 +33,16 @@ class GameTitleArg(StrEnum):
         return GameTitle(self.value)
 
 
+def _resolve_title(save: Path, title: GameTitleArg | None) -> GameTitle:
+    """``--title`` 明示指定があればそれを使い，無ければ拡張子から推定．
+
+    ``.a7s`` → Anno 1800 / ``.a8s`` → Anno 117．判別不能なら ValueError．
+    """
+    if title is not None:
+        return title.to_title()
+    return GameTitle.from_save_path(save)
+
+
 class SummaryAxis(StrEnum):
     ITEM = "item"
     ROUTE = "route"
@@ -73,8 +83,11 @@ def _emit_json(payload: object) -> None:
 def list_trades(
     save: Annotated[Path, typer.Argument(help="Path to the save file.")],
     title: Annotated[
-        GameTitleArg, typer.Option("--title", help="Game title.")
-    ] = GameTitleArg.ANNO_117,
+        GameTitleArg | None,
+        typer.Option(
+            "--title", help="Game title. Defaults to extension: .a7s=anno1800 / .a8s=anno117."
+        ),
+    ] = None,
     locale: Annotated[str, typer.Option("--locale", help="Display locale.")] = "en",
     session: Annotated[
         str | None, typer.Option("--session", help="Filter by session id (e.g. '0' / '1').")
@@ -88,7 +101,7 @@ def list_trades(
 ) -> None:
     """List every TradeEvent extracted from SAVE."""
     _ensure_format_supported(fmt)
-    title_v = title.to_title()
+    title_v = _resolve_title(save, title)
     events = list(filter_events(_events(save, title_v, locale), session=session, island=island))
     # minutes_ago は max(timestamp_tick) 基準．newest event = 0.0．
     # clock.py の docstring 通り TICKS_PER_MINUTE で割る．
@@ -134,8 +147,11 @@ def summary(
     save: Annotated[Path, typer.Argument(help="Path to the save file.")],
     by: Annotated[SummaryAxis, typer.Option("--by", help="Aggregation axis.")] = SummaryAxis.ITEM,
     title: Annotated[
-        GameTitleArg, typer.Option("--title", help="Game title.")
-    ] = GameTitleArg.ANNO_117,
+        GameTitleArg | None,
+        typer.Option(
+            "--title", help="Game title. Defaults to extension: .a7s=anno1800 / .a8s=anno117."
+        ),
+    ] = None,
     locale: Annotated[str, typer.Option("--locale", help="Display locale.")] = "en",
     session: Annotated[
         str | None, typer.Option("--session", help="Filter by session id (e.g. '0' / '1').")
@@ -149,7 +165,7 @@ def summary(
 ) -> None:
     """Summarise trades by item or by route."""
     _ensure_format_supported(fmt)
-    title_v = title.to_title()
+    title_v = _resolve_title(save, title)
     events = _events(save, title_v, locale)
     if by is SummaryAxis.ITEM:
         item_rows = by_item(events, session=session, island=island)
@@ -193,8 +209,11 @@ def diff(
     after: Annotated[Path, typer.Argument(help="Later save file.")],
     by: Annotated[SummaryAxis, typer.Option("--by", help="Aggregation axis.")] = SummaryAxis.ITEM,
     title: Annotated[
-        GameTitleArg, typer.Option("--title", help="Game title.")
-    ] = GameTitleArg.ANNO_117,
+        GameTitleArg | None,
+        typer.Option(
+            "--title", help="Game title. Defaults to extension: .a7s=anno1800 / .a8s=anno117."
+        ),
+    ] = None,
     locale: Annotated[str, typer.Option("--locale", help="Display locale.")] = "en",
     session: Annotated[
         str | None, typer.Option("--session", help="Filter by session id (e.g. '0' / '1').")
@@ -215,7 +234,8 @@ def diff(
 ) -> None:
     """Diff trade activity between BEFORE and AFTER save files."""
     _ensure_format_supported(fmt)
-    title_v = title.to_title()
+    # diff には save がないので before で推定 (前後とも同じゲームという前提)．
+    title_v = _resolve_title(before, title)
     before_events = list(_events(before, title_v, locale))
     after_events = list(_events(after, title_v, locale))
     if by is SummaryAxis.ITEM:

--- a/src/anno_save_analyzer/cli/tui.py
+++ b/src/anno_save_analyzer/cli/tui.py
@@ -26,8 +26,11 @@ _THEME_SENTINEL = "__from_config__"
 def _launch(
     save: Annotated[Path, typer.Argument(help="Save file (.a7s / .a8s).")],
     title: Annotated[
-        GameTitleArg, typer.Option("--title", help="Game title.")
-    ] = GameTitleArg.ANNO_117,
+        GameTitleArg | None,
+        typer.Option(
+            "--title", help="Game title. Defaults to extension: .a7s=anno1800 / .a8s=anno117."
+        ),
+    ] = None,
     locale: Annotated[
         str,
         typer.Option(
@@ -106,7 +109,8 @@ def _launch(
             bar.label = f"  [{step}/{stage_total}] {stage}"
             bar.update(1)
 
-        state = load_state(save, title=title.to_title(), locale=locale, progress=_progress)
+        resolved_title = title.to_title() if title is not None else GameTitle.from_save_path(save)
+        state = load_state(save, title=resolved_title, locale=locale, progress=_progress)
     typer.secho("  ✓ ready", err=True, fg=typer.colors.GREEN)
 
     app = TradeApp(state, theme=theme_value, persist_settings=True)

--- a/src/anno_save_analyzer/cli/tui.py
+++ b/src/anno_save_analyzer/cli/tui.py
@@ -8,6 +8,7 @@ from typing import Annotated
 
 import typer
 
+from anno_save_analyzer.cli._title import resolve_title
 from anno_save_analyzer.trade.models import GameTitle
 
 
@@ -109,7 +110,7 @@ def _launch(
             bar.label = f"  [{step}/{stage_total}] {stage}"
             bar.update(1)
 
-        resolved_title = title.to_title() if title is not None else GameTitle.from_save_path(save)
+        resolved_title = resolve_title(save, title.to_title() if title is not None else None)
         state = load_state(save, title=resolved_title, locale=locale, progress=_progress)
     typer.secho("  ✓ ready", err=True, fg=typer.colors.GREEN)
 

--- a/src/anno_save_analyzer/trade/analysis.py
+++ b/src/anno_save_analyzer/trade/analysis.py
@@ -1,0 +1,192 @@
+"""既存 StorageTrends / TradeEvent から派生する分析指標．
+
+書記長要望 (v0.4.3) の「物資枯渇まで何分」「需要供給バランス」「不足物資一覧」を
+純関数で計算する．人口 × 需要 の結合分析は v0.6 (別 PR) で追加予定．
+
+依存:
+- ``storage.IslandStorageTrend`` (1 島 × 1 物資の時系列)
+- ``clock.SAMPLE_INTERVAL_TICKS`` (1 サンプル = 何 tick か)
+
+slope は「サンプル単位 per unit-x」．``SAMPLE_INTERVAL_TICKS == TICKS_PER_MINUTE``
+なら slope = 「分あたり変化量 (単位 物資/分)」になる．現状 1 sample = 1 minute
+前提なので slope がそのまま「物資/分」の変化率として使える．
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterable
+
+from pydantic import BaseModel, Field, computed_field
+
+from .models import Item
+from .storage import IslandStorageTrend
+
+
+class IslandProductRunway(BaseModel):
+    """1 島 × 1 物資の「枯渇残り分数」．"""
+
+    island_name: str
+    product_guid: int
+    latest: int
+    """最新サンプル値．0 の物資は既に枯渇．"""
+    slope_per_min: float
+    """サンプル単位の線形回帰 slope．1 sample = 1 min なら「分あたり変化量」．
+    正なら増加トレンド (生産 > 消費)，負なら減少 (消費 > 生産)．"""
+
+    model_config = {"frozen": True}
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def runway_min(self) -> float | None:
+        """``slope_per_min`` が負のときに限り ``latest / |slope|`` を返す．
+
+        増加 / 平坦は None (枯渇しない)．既に 0 の場合は 0.0 (即枯渇)．
+        """
+        if self.latest <= 0:
+            return 0.0
+        if self.slope_per_min >= 0:
+            return None
+        return float(self.latest) / -self.slope_per_min
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def status(self) -> str:
+        """表示用ステータス label．"""
+        if self.latest <= 0:
+            return "depleted"
+        if self.slope_per_min >= 0:
+            return "stable_or_growing"
+        r = self.runway_min
+        if r is None:  # pragma: no cover - slope >= 0 の場合は上で拾う
+            return "stable_or_growing"
+        if r < 10:
+            return "critical"
+        if r < 60:
+            return "warning"
+        return "ok"
+
+
+class ProductBalance(BaseModel):
+    """1 物資の島横断な供給/需要バランス．"""
+
+    product_guid: int
+    surplus_islands: tuple[str, ...] = Field(default_factory=tuple)
+    """slope > 0 の島（黒字＝生産過多）"""
+    deficit_islands: tuple[str, ...] = Field(default_factory=tuple)
+    """slope < 0 の島（赤字＝消費過多）"""
+    net_slope_per_min: float = 0.0
+    """全島の slope 合計．正なら全体余剰，負なら赤字．"""
+
+    model_config = {"frozen": True}
+
+
+def compute_runways(trends: Iterable[IslandStorageTrend]) -> list[IslandProductRunway]:
+    """trend 群を runway 指標に変換．空 / None 安全で non-trend は skip．
+
+    結果は ``runway_min`` 昇順 (逼迫順)．``None`` (安定/増加) は末尾にまとめる．
+    """
+    out: list[IslandProductRunway] = []
+    for tr in trends:
+        slope = tr.points.slope
+        out.append(
+            IslandProductRunway(
+                island_name=tr.island_name,
+                product_guid=tr.product_guid,
+                latest=tr.latest,
+                slope_per_min=slope,
+            )
+        )
+
+    def _sort_key(r: IslandProductRunway) -> tuple[int, float]:
+        # None は末尾にするため (has_runway, value) キー．
+        if r.runway_min is None:
+            return (1, math.inf)
+        return (0, r.runway_min)
+
+    out.sort(key=_sort_key)
+    return out
+
+
+def shortage_list(
+    trends: Iterable[IslandStorageTrend],
+    *,
+    threshold_min: float | None = 60.0,
+) -> list[IslandProductRunway]:
+    """不足しとる (runway <= threshold) もの だけを抽出．
+
+    既に枯渇 (``runway_min == 0``) は最優先で含める．``threshold_min=None``
+    なら slope < 0 な全件を返す (枯渇予定全部)．
+    """
+    runways = compute_runways(trends)
+    out: list[IslandProductRunway] = []
+    for r in runways:
+        if r.runway_min is None:
+            continue  # 安定 / 増加は shortage じゃない
+        if threshold_min is None or r.runway_min <= threshold_min:
+            out.append(r)
+    return out
+
+
+def supply_demand_balance(
+    trends: Iterable[IslandStorageTrend],
+) -> list[ProductBalance]:
+    """物資ごとに「黒字島 / 赤字島 / 合計 slope」を集計．
+
+    結果は ``net_slope`` 降順 (余剰順)．ソートで全体状況が上から読める．
+    """
+    surplus: dict[int, list[str]] = defaultdict(list)
+    deficit: dict[int, list[str]] = defaultdict(list)
+    net: dict[int, float] = defaultdict(float)
+
+    for tr in trends:
+        slope = tr.points.slope
+        net[tr.product_guid] += slope
+        if slope > 0:
+            surplus[tr.product_guid].append(tr.island_name)
+        elif slope < 0:
+            deficit[tr.product_guid].append(tr.island_name)
+
+    all_guids = set(net.keys())
+    out: list[ProductBalance] = []
+    for guid in all_guids:
+        out.append(
+            ProductBalance(
+                product_guid=guid,
+                surplus_islands=tuple(sorted(surplus.get(guid, []))),
+                deficit_islands=tuple(sorted(deficit.get(guid, []))),
+                net_slope_per_min=net[guid],
+            )
+        )
+    out.sort(key=lambda p: -p.net_slope_per_min)
+    return out
+
+
+def display_runway_rows(
+    runways: Iterable[IslandProductRunway],
+    items: dict[int, Item] | object,
+    locale: str = "en",
+) -> list[dict[str, object]]:
+    """runway list を dict に展開する presenter．HTML/CSV export で流用．
+
+    ``items`` は ``ItemDictionary`` でも plain ``dict[int, Item]`` でも OK．
+    """
+    out: list[dict[str, object]] = []
+    for r in runways:
+        try:
+            product_name = items[r.product_guid].display_name(locale)  # type: ignore[index]
+        except (KeyError, AttributeError):
+            product_name = f"Good_{r.product_guid}"
+        out.append(
+            {
+                "island_name": r.island_name,
+                "product_guid": r.product_guid,
+                "product_name": product_name,
+                "latest": r.latest,
+                "slope_per_min": round(r.slope_per_min, 3),
+                "runway_min": (round(r.runway_min, 1) if r.runway_min is not None else None),
+                "status": r.status,
+            }
+        )
+    return out

--- a/src/anno_save_analyzer/trade/analysis.py
+++ b/src/anno_save_analyzer/trade/analysis.py
@@ -83,8 +83,9 @@ class ProductBalance(BaseModel):
 
 
 def compute_runways(trends: Iterable[IslandStorageTrend]) -> list[IslandProductRunway]:
-    """trend 群を runway 指標に変換．空 / None 安全で non-trend は skip．
+    """trend 群を runway 指標に変換．空 iterable に対しても安全に処理する．
 
+    各 trend はそのまま ``IslandProductRunway`` に変換される。
     結果は ``runway_min`` 昇順 (逼迫順)．``None`` (安定/増加) は末尾にまとめる．
     """
     out: list[IslandProductRunway] = []

--- a/src/anno_save_analyzer/trade/extract.py
+++ b/src/anno_save_analyzer/trade/extract.py
@@ -98,9 +98,14 @@ def load_outer_filedb(save_path: Path) -> bytes:
     - zlib 圧縮 (``0x78 9c / da / 01``) → 展開して bare bytes
     - それ以外 → bare FileDB バイナリとしてそのまま返す
     """
-    raw = save_path.read_bytes()
-    if raw.startswith(b"Resource File V2."):
+    rda_magic = b"Resource File V2."
+    with save_path.open("rb") as fh:
+        magic = fh.read(len(rda_magic))
+
+    if magic.startswith(rda_magic):
         return extract_inner_filedb(save_path)
+
+    raw = save_path.read_bytes()
     if raw[:2] in (b"\x78\x9c", b"\x78\xda", b"\x78\x01"):
         return zlib.decompress(raw)
     return raw

--- a/src/anno_save_analyzer/trade/extract.py
+++ b/src/anno_save_analyzer/trade/extract.py
@@ -89,14 +89,18 @@ def extract_from_outer(
 
 
 def load_outer_filedb(save_path: Path) -> bytes:
-    """``.a7s`` / ``.a8s`` を解凍して内部 FileDB バイナリを返す．
+    """セーブファイルを解凍して内部 FileDB バイナリを返す．
 
-    bare FileDB バイナリ (テスト用 ``.bin``) も自動判定．zlib 圧縮済なら展開．
+    extension ではなく **magic prefix で形式判定**する (実 save は必ず
+    ``.a7s`` / ``.a8s``．テスト fixture や手動展開済みファイルにも対応するため)：
+
+    - RDA container (``Resource File V2.`` の ASCII prefix) → RDA 層を剥ぐ
+    - zlib 圧縮 (``0x78 9c / da / 01``) → 展開して bare bytes
+    - それ以外 → bare FileDB バイナリとしてそのまま返す
     """
-    suffix = save_path.suffix.lower()
-    if suffix in {".a7s", ".a8s"}:
-        return extract_inner_filedb(save_path)
     raw = save_path.read_bytes()
+    if raw.startswith(b"Resource File V2."):
+        return extract_inner_filedb(save_path)
     if raw[:2] in (b"\x78\x9c", b"\x78\xda", b"\x78\x01"):
         return zlib.decompress(raw)
     return raw

--- a/src/anno_save_analyzer/trade/html_export.py
+++ b/src/anno_save_analyzer/trade/html_export.py
@@ -1,0 +1,511 @@
+"""単一 HTML ダッシュボード生成．
+
+``^O`` export に HTML を追加するための純関数．全データを JSON 埋め込みで
+持ち，Plotly を CDN ロードしてクライアント側で描画する．1 ファイルだけで
+書記長のブラウザでそのまま開ける．
+
+設計方針:
+
+- 依存を増やさない．Plotly 等は CDN 参照で良い．オフライン運用が必要に
+  なったら inline bundle 化するが現状 YAGNI．
+- データは ``<script type="application/json">`` に載せて JS で描画．
+  markdown の表も添えて jq / Excel / pandas にコピペしやすく．
+- Section: Overview / Trade / Inventory / Analysis．``^T`` 的な遷移は
+  anchor link で済ます．
+- セーブ由来の文字列 (島名 / ルート名 / アイテム名) は信頼できん前提で
+  JS 側で textContent / createElement 経由でのみ DOM に差し込む．
+  innerHTML でのエスケープ漏れは避ける．
+
+依存は stdlib + ``html`` (escape 用) のみ．
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from .aggregate import ItemSummary, RouteSummary
+from .analysis import (
+    ProductBalance,
+    compute_runways,
+    display_runway_rows,
+    shortage_list,
+    supply_demand_balance,
+)
+from .clock import TICKS_PER_MINUTE, latest_tick
+from .items import ItemDictionary
+from .models import GameTitle, Locale, TradeEvent
+from .storage import IslandStorageTrend
+
+_PLOTLY_CDN = "https://cdn.plot.ly/plotly-2.35.2.min.js"
+
+
+def _localize_name(items: ItemDictionary | dict, guid: int, locale: str) -> str:
+    try:
+        return items[guid].display_name(locale)
+    except (KeyError, AttributeError):
+        return f"Good_{guid}"
+
+
+def _events_payload(
+    events: Iterable[TradeEvent], items: ItemDictionary, locale: str
+) -> list[dict[str, Any]]:
+    events_list = list(events)
+    now_tick = latest_tick(e.timestamp_tick for e in events_list if e.timestamp_tick is not None)
+    out: list[dict[str, Any]] = []
+    for ev in events_list:
+        min_ago: float | None
+        if ev.timestamp_tick is None or now_tick is None:
+            min_ago = None
+        else:
+            min_ago = round((now_tick - ev.timestamp_tick) / TICKS_PER_MINUTE, 2)
+        out.append(
+            {
+                "tick": ev.timestamp_tick,
+                "min_ago": min_ago,
+                "session": ev.session_id,
+                "island": ev.island_name,
+                "route_id": ev.route_id,
+                "route_name": ev.route_name,
+                "partner_id": ev.partner.id if ev.partner else None,
+                "partner_kind": ev.partner.kind if ev.partner else None,
+                "item_guid": ev.item.guid,
+                "item_name": _localize_name(items, ev.item.guid, locale),
+                "amount": ev.amount,
+                "total_price": ev.total_price,
+            }
+        )
+    return out
+
+
+def _items_payload(summaries: Iterable[ItemSummary], locale: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for s in summaries:
+        out.append(
+            {
+                "guid": s.item.guid,
+                "name": s.display_name(locale),
+                "category": s.item.category,
+                "bought": s.bought,
+                "sold": s.sold,
+                "net_qty": s.net_qty,
+                "net_gold": s.net_gold,
+                "event_count": s.event_count,
+                "last_seen_tick": s.last_seen_tick,
+            }
+        )
+    return out
+
+
+def _routes_payload(
+    summaries: Iterable[RouteSummary],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for s in summaries:
+        out.append(
+            {
+                "route_id": s.route_id,
+                "route_name": s.route_name,
+                "partner_kind": s.partner_kind,
+                "bought": s.bought,
+                "sold": s.sold,
+                "net_gold": s.net_gold,
+                "event_count": s.event_count,
+                "last_seen_tick": s.last_seen_tick,
+            }
+        )
+    return out
+
+
+def _inventory_payload(
+    trends: Iterable[IslandStorageTrend], items: ItemDictionary, locale: str
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for tr in trends:
+        out.append(
+            {
+                "island": tr.island_name,
+                "guid": tr.product_guid,
+                "name": _localize_name(items, tr.product_guid, locale),
+                "latest": tr.latest,
+                "peak": tr.peak,
+                "mean": round(tr.points.mean, 2),
+                "slope_per_min": round(tr.points.slope, 3),
+                "last_point_tick": tr.last_point_tick,
+                "samples": list(tr.points.samples),
+            }
+        )
+    return out
+
+
+def _balance_payload(
+    balances: Iterable[ProductBalance], items: ItemDictionary, locale: str
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for b in balances:
+        out.append(
+            {
+                "guid": b.product_guid,
+                "name": _localize_name(items, b.product_guid, locale),
+                "net_slope_per_min": round(b.net_slope_per_min, 3),
+                "surplus_islands": list(b.surplus_islands),
+                "deficit_islands": list(b.deficit_islands),
+            }
+        )
+    return out
+
+
+def build_dashboard_data(
+    *,
+    events: Iterable[TradeEvent],
+    item_summaries: Iterable[ItemSummary],
+    route_summaries: Iterable[RouteSummary],
+    inventory_trends: Iterable[IslandStorageTrend],
+    items: ItemDictionary,
+    title: GameTitle,
+    locale: Locale = "en",
+    save_name: str = "save",
+) -> dict[str, Any]:
+    """HTML 埋め込み用 JSON blob を組み立てる．純関数．"""
+    trends_list = list(inventory_trends)
+    runways = compute_runways(trends_list)
+    shortages = shortage_list(trends_list, threshold_min=120.0)
+    balances = supply_demand_balance(trends_list)
+
+    return {
+        "meta": {
+            "title": str(title.value),
+            "save": save_name,
+            "locale": locale,
+            "ticks_per_minute": TICKS_PER_MINUTE,
+        },
+        "events": _events_payload(events, items, locale),
+        "items": _items_payload(item_summaries, locale),
+        "routes": _routes_payload(route_summaries),
+        "inventory": _inventory_payload(trends_list, items, locale),
+        "runways": display_runway_rows(runways, items, locale),
+        "shortages": display_runway_rows(shortages, items, locale),
+        "balances": _balance_payload(balances, items, locale),
+    }
+
+
+def dashboard_to_html(
+    data: dict[str, Any],
+    *,
+    title_text: str = "anno-save-analyzer dashboard",
+) -> str:
+    """JSON データから単一 HTML (Plotly + 表 + 埋め込み JSON) を生成．"""
+    data_json = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    # XSS 対策: embedded JSON 中の ``</script>`` が外側 script タグを誤って
+    # 閉じてしまうのを防ぐ．JSON parser は ``\/`` を ``/`` として読めるので
+    # 見た目不変のまま無害化できる．``<!--`` / ``-->`` も同じ脅威なので escape．
+    data_json = data_json.replace("</", "<\\/").replace("<!--", "<\\!--").replace("-->", "--\\>")
+    meta = data["meta"]
+    title_html = html.escape(title_text)
+    save_html = html.escape(meta.get("save", "save"))
+    title_label = html.escape(meta.get("title", ""))
+    return _TEMPLATE.format(
+        title_html=title_html,
+        save_html=save_html,
+        title_label=title_label,
+        locale=html.escape(meta.get("locale", "en")),
+        plotly_cdn=_PLOTLY_CDN,
+        data_json=data_json,
+    )
+
+
+# HTML template. Double-braced literals are .format escapes for JS.
+# JS is strictly DOM-only (textContent / createElement) so save-derived strings
+# are never interpolated via innerHTML.
+_TEMPLATE = """<!DOCTYPE html>
+<html lang="{locale}">
+<head>
+<meta charset="UTF-8">
+<title>{title_html} — {save_html}</title>
+<script src="{plotly_cdn}"></script>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", sans-serif;
+         margin: 0; padding: 0; color: #e0e0e0; background: #1a1a1a; }}
+  header {{ padding: 1em 2em; border-bottom: 1px solid #333; display: flex; gap: 2em; align-items: baseline; }}
+  header h1 {{ margin: 0; font-size: 1.4em; color: #ffd670; }}
+  header .meta {{ color: #888; font-size: 0.9em; }}
+  nav {{ padding: 0 2em; border-bottom: 1px solid #333; background: #222; }}
+  nav a {{ display: inline-block; padding: 0.8em 1em; color: #ffd670; text-decoration: none; border-bottom: 2px solid transparent; }}
+  nav a:hover {{ border-bottom-color: #ffd670; }}
+  main {{ padding: 2em; max-width: 1400px; margin: 0 auto; }}
+  section {{ margin-bottom: 3em; scroll-margin-top: 1em; }}
+  section h2 {{ color: #ffd670; border-bottom: 1px solid #444; padding-bottom: 0.3em; }}
+  table {{ border-collapse: collapse; width: 100%; margin-top: 1em; font-size: 0.9em; }}
+  th, td {{ padding: 0.4em 0.8em; text-align: left; border-bottom: 1px solid #2a2a2a; }}
+  th {{ background: #262626; position: sticky; top: 0; cursor: pointer; }}
+  th:hover {{ background: #303030; }}
+  tr:hover td {{ background: #252525; }}
+  td.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  .chart {{ background: #222; border: 1px solid #333; padding: 0.5em; border-radius: 4px; }}
+  .status-depleted {{ color: #ff5555; font-weight: bold; }}
+  .status-critical {{ color: #ff9955; font-weight: bold; }}
+  .status-warning {{ color: #ffd670; }}
+  .status-ok {{ color: #66dd66; }}
+  .status-stable_or_growing {{ color: #5ba8ff; }}
+  .hint {{ color: #888; font-size: 0.85em; margin-top: 0.3em; }}
+  ul.stats {{ list-style: none; padding: 0; display: flex; gap: 2em; flex-wrap: wrap; }}
+  ul.stats li b {{ color: #ffd670; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>{title_html}</h1>
+  <div class="meta">save: <b>{save_html}</b> · title: <b>{title_label}</b> · locale: <b>{locale}</b></div>
+</header>
+<nav>
+  <a href="#overview">Overview</a>
+  <a href="#shortages">Shortages</a>
+  <a href="#balance">Supply / Demand</a>
+  <a href="#inventory">Inventory</a>
+  <a href="#items">Items</a>
+  <a href="#routes">Routes</a>
+  <a href="#events">Events</a>
+</nav>
+<main>
+  <section id="overview">
+    <h2>Overview</h2>
+    <ul class="stats" id="overview-stats"></ul>
+    <div class="chart" id="chart-trade-volume"></div>
+    <div class="hint">Trade volume over time (points per session).</div>
+  </section>
+
+  <section id="shortages">
+    <h2>Shortages <span class="hint">(runway ≤ 120 min)</span></h2>
+    <div class="chart" id="chart-shortages" style="min-height: 420px;"></div>
+    <div id="shortages-table"></div>
+  </section>
+
+  <section id="balance">
+    <h2>Supply / Demand balance per good</h2>
+    <div id="balance-table"></div>
+    <div class="hint">Sorted by net slope (/ min) across all islands. Positive = surplus, negative = deficit.</div>
+  </section>
+
+  <section id="inventory">
+    <h2>Inventory (per island × good)</h2>
+    <div id="inventory-table"></div>
+  </section>
+
+  <section id="items">
+    <h2>Trade volume by item</h2>
+    <div id="items-table"></div>
+  </section>
+
+  <section id="routes">
+    <h2>Trade volume by route</h2>
+    <div id="routes-table"></div>
+  </section>
+
+  <section id="events">
+    <h2>Events (raw)</h2>
+    <div class="hint">Trade events. Use browser search (Ctrl+F) or copy into a spreadsheet.</div>
+    <div id="events-table"></div>
+  </section>
+</main>
+<script type="application/json" id="dashboard-data">{data_json}</script>
+<script>
+(function() {{
+  const raw = document.getElementById('dashboard-data').textContent;
+  const D = JSON.parse(raw);
+
+  function el(tag, props, children) {{
+    const node = document.createElement(tag);
+    if (props) {{
+      for (const k in props) {{
+        if (k === 'class') node.className = props[k];
+        else if (k === 'text') node.textContent = props[k];
+        else node.setAttribute(k, props[k]);
+      }}
+    }}
+    if (children) for (const c of children) {{
+      if (c == null) continue;
+      node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+    }}
+    return node;
+  }}
+
+  function statLi(label, value) {{
+    return el('li', null, [label + ': ', el('b', {{text: value}})]);
+  }}
+
+  // --- Overview stats ---
+  const statsUl = document.getElementById('overview-stats');
+  const nEvents = D.events.length;
+  const totalGold = D.events.reduce((a, e) => a + (e.total_price || 0), 0);
+  const nItems = new Set(D.events.map(e => e.item_guid)).size;
+  const nRoutes = new Set(D.events.filter(e => e.route_id).map(e => e.route_id)).size;
+  const nIslands = new Set(D.inventory.map(t => t.island)).size;
+  [
+    ['Events', nEvents.toLocaleString()],
+    ['Distinct items', String(nItems)],
+    ['Distinct routes', String(nRoutes)],
+    ['Player islands', String(nIslands)],
+    ['Net gold', totalGold.toLocaleString() + ' g'],
+  ].forEach(([l, v]) => statsUl.appendChild(statLi(l, v)));
+
+  // --- Trade volume chart ---
+  const bySession = {{}};
+  D.events.forEach(ev => {{
+    if (ev.min_ago == null) return;
+    const s = ev.session || '-';
+    if (!bySession[s]) bySession[s] = {{x: [], y: []}};
+    bySession[s].x.push(-ev.min_ago);
+    bySession[s].y.push(Math.abs(ev.amount));
+  }});
+  const traces = Object.keys(bySession).sort().map(s => ({{
+    x: bySession[s].x, y: bySession[s].y, mode: 'markers', type: 'scatter',
+    name: 'session ' + s, marker: {{size: 4, opacity: 0.5}}
+  }}));
+  Plotly.newPlot('chart-trade-volume', traces, {{
+    paper_bgcolor: '#222', plot_bgcolor: '#222',
+    font: {{color: '#ddd'}},
+    xaxis: {{title: 'minutes ago', autorange: 'reversed'}},
+    yaxis: {{title: '|amount|'}},
+    margin: {{t: 20, r: 20, b: 40, l: 60}},
+    height: 360
+  }}, {{displaylogo: false, responsive: true}});
+
+  // --- Shortages chart ---
+  const sh = D.shortages.slice(0, 40);
+  Plotly.newPlot('chart-shortages', [{{
+    type: 'bar', orientation: 'h',
+    x: sh.map(r => r.runway_min),
+    y: sh.map(r => r.product_name + ' @ ' + r.island_name),
+    marker: {{color: sh.map(r => r.status === 'depleted' ? '#ff5555' : r.status === 'critical' ? '#ff9955' : '#ffd670')}},
+    text: sh.map(r => String(r.runway_min) + 'm'),
+    textposition: 'auto'
+  }}], {{
+    paper_bgcolor: '#222', plot_bgcolor: '#222',
+    font: {{color: '#ddd'}},
+    xaxis: {{title: 'minutes until empty'}},
+    yaxis: {{automargin: true}},
+    margin: {{t: 20, r: 20, b: 40, l: 20}},
+  }}, {{displaylogo: false, responsive: true}});
+
+  // --- Generic sortable table renderer (textContent only, no innerHTML) ---
+  function renderTable(containerId, rows, columns) {{
+    const container = document.getElementById(containerId);
+    container.textContent = '';
+    if (!rows.length) {{
+      container.appendChild(el('p', {{class: 'hint', text: '(no rows)'}}));
+      return;
+    }}
+    let sortKey = null, sortAsc = true;
+    function buildTable() {{
+      container.textContent = '';
+      const sorted = sortKey ? [...rows].sort((a, b) => {{
+        const av = a[sortKey], bv = b[sortKey];
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (typeof av === 'number' && typeof bv === 'number') return sortAsc ? av - bv : bv - av;
+        return sortAsc ? String(av).localeCompare(String(bv)) : String(bv).localeCompare(String(av));
+      }}) : rows;
+      const table = el('table');
+      const thead = el('thead');
+      const headerRow = el('tr');
+      columns.forEach(c => {{
+        const th = el('th', {{text: c.label + (sortKey === c.key ? (sortAsc ? ' ▲' : ' ▼') : '')}});
+        th.addEventListener('click', () => {{
+          if (sortKey === c.key) sortAsc = !sortAsc;
+          else {{ sortKey = c.key; sortAsc = true; }}
+          buildTable();
+        }});
+        headerRow.appendChild(th);
+      }});
+      thead.appendChild(headerRow);
+      table.appendChild(thead);
+      const tbody = el('tbody');
+      sorted.forEach(r => {{
+        const tr = el('tr');
+        columns.forEach(c => {{
+          const v = r[c.key];
+          let disp;
+          if (v == null) disp = '';
+          else if (Array.isArray(v)) disp = v.join(', ');
+          else if (typeof v === 'number') disp = v.toLocaleString();
+          else disp = String(v);
+          const td = el('td', {{text: disp}});
+          if (typeof v === 'number') td.className = 'num';
+          if (c.statusCol && r.status) td.className = 'status-' + r.status;
+          tr.appendChild(td);
+        }});
+        tbody.appendChild(tr);
+      }});
+      table.appendChild(tbody);
+      container.appendChild(table);
+    }}
+    buildTable();
+  }}
+
+  renderTable('shortages-table', D.shortages, [
+    {{key: 'island_name', label: 'Island'}},
+    {{key: 'product_name', label: 'Good'}},
+    {{key: 'latest', label: 'Latest'}},
+    {{key: 'slope_per_min', label: 'Slope/min'}},
+    {{key: 'runway_min', label: 'Runway (min)'}},
+    {{key: 'status', label: 'Status', statusCol: true}},
+  ]);
+
+  renderTable('balance-table', D.balances, [
+    {{key: 'name', label: 'Good'}},
+    {{key: 'net_slope_per_min', label: 'Net slope/min'}},
+    {{key: 'surplus_islands', label: 'Surplus islands'}},
+    {{key: 'deficit_islands', label: 'Deficit islands'}},
+  ]);
+
+  renderTable('inventory-table', D.inventory, [
+    {{key: 'island', label: 'Island'}},
+    {{key: 'name', label: 'Good'}},
+    {{key: 'latest', label: 'Latest'}},
+    {{key: 'peak', label: 'Peak'}},
+    {{key: 'mean', label: 'Mean'}},
+    {{key: 'slope_per_min', label: 'Slope/min'}},
+  ]);
+
+  renderTable('items-table', D.items, [
+    {{key: 'name', label: 'Good'}},
+    {{key: 'bought', label: 'Bought'}},
+    {{key: 'sold', label: 'Sold'}},
+    {{key: 'net_qty', label: 'Net qty'}},
+    {{key: 'net_gold', label: 'Net gold'}},
+    {{key: 'event_count', label: 'Events'}},
+  ]);
+
+  renderTable('routes-table', D.routes, [
+    {{key: 'route_id', label: 'Route ID'}},
+    {{key: 'route_name', label: 'Route name'}},
+    {{key: 'partner_kind', label: 'Kind'}},
+    {{key: 'bought', label: 'Bought'}},
+    {{key: 'sold', label: 'Sold'}},
+    {{key: 'net_gold', label: 'Net gold'}},
+    {{key: 'event_count', label: 'Events'}},
+  ]);
+
+  const eventRows = D.events.slice(0, 2000);
+  renderTable('events-table', eventRows, [
+    {{key: 'min_ago', label: 'min ago'}},
+    {{key: 'island', label: 'Island'}},
+    {{key: 'route_name', label: 'Route'}},
+    {{key: 'partner_kind', label: 'Kind'}},
+    {{key: 'item_name', label: 'Good'}},
+    {{key: 'amount', label: 'Amount'}},
+    {{key: 'total_price', label: 'Gold'}},
+  ]);
+  if (D.events.length > 2000) {{
+    const hint = el('p', {{class: 'hint',
+      text: 'Showing first 2,000 of ' + D.events.length.toLocaleString() + ' events. Full data in embedded JSON.'}});
+    document.getElementById('events-table').appendChild(hint);
+  }}
+}})();
+</script>
+</body>
+</html>
+"""

--- a/src/anno_save_analyzer/trade/html_export.py
+++ b/src/anno_save_analyzer/trade/html_export.py
@@ -198,10 +198,11 @@ def dashboard_to_html(
 ) -> str:
     """JSON データから単一 HTML (Plotly + 表 + 埋め込み JSON) を生成．"""
     data_json = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
-    # XSS 対策: embedded JSON 中の ``</script>`` が外側 script タグを誤って
-    # 閉じてしまうのを防ぐ．JSON parser は ``\/`` を ``/`` として読めるので
-    # 見た目不変のまま無害化できる．``<!--`` / ``-->`` も同じ脅威なので escape．
-    data_json = data_json.replace("</", "<\\/").replace("<!--", "<\\!--").replace("-->", "--\\>")
+    # XSS 対策: embedded JSON 中の ``</script>`` や ``<!--`` / ``-->`` が
+    # HTML parser に解釈されるのを防ぐ．後処理では JSON として常に合法な
+    # escape のみを使う必要があるため、``<`` / ``>`` を Unicode escape に
+    # 置換する。JSON parser は ``\\u003c`` / ``\\u003e`` を元の文字として読む。
+    data_json = data_json.replace("<", "\\u003c").replace(">", "\\u003e")
     meta = data["meta"]
     title_html = html.escape(title_text)
     save_html = html.escape(meta.get("save", "save"))

--- a/src/anno_save_analyzer/trade/models.py
+++ b/src/anno_save_analyzer/trade/models.py
@@ -28,6 +28,28 @@ class GameTitle(StrEnum):
     ANNO_1800 = "anno1800"
     ANNO_117 = "anno117"
 
+    @classmethod
+    def from_save_path(cls, path: object) -> GameTitle:
+        """セーブファイルの拡張子からタイトルを判定．
+
+        - ``.a7s`` → Anno 1800 (book 1 的な旧世代 container)
+        - ``.a8s`` → Anno 117: Pax Romana (新世代 container)
+
+        判別不能な拡張子なら ``ValueError``．``path`` は ``str`` でも ``Path`` でも OK．
+        """
+        from pathlib import Path
+
+        suffix = Path(str(path)).suffix.lower()
+        if suffix == ".a7s":
+            return cls.ANNO_1800
+        if suffix == ".a8s":
+            return cls.ANNO_117
+        raise ValueError(
+            f"Cannot infer game title from extension {suffix!r}; "
+            f"expected '.a7s' (Anno 1800) or '.a8s' (Anno 117). "
+            f"Use --title to override."
+        )
+
 
 class Item(BaseModel):
     """物資（GoodGuid に対応）．names は locale → name の dict．"""

--- a/src/anno_save_analyzer/tui/app.py
+++ b/src/anno_save_analyzer/tui/app.py
@@ -248,6 +248,23 @@ class TradeApp(App[None]):
             for name in island_names:
                 inventory_trends.extend(self._state.storage_by_island.get(name, ()))
 
+        # HTML ダッシュボードは Plotly + 分析 (枯渇 / 需要供給 / 不足) 込みで
+        # 1 ファイルにまとめる．CSV は Excel 分析用に残す．
+        from anno_save_analyzer.trade.html_export import (
+            build_dashboard_data,
+            dashboard_to_html,
+        )
+
+        dashboard_data = build_dashboard_data(
+            events=events,
+            item_summaries=item_rows,
+            route_summaries=route_rows,
+            inventory_trends=inventory_trends,
+            items=self._state.items,
+            title=self._state.title,
+            locale=locale,
+            save_name=self._state.save_path.name,
+        )
         targets = [
             (
                 f"{basename}_items{suffix}_{stamp}.csv",
@@ -268,6 +285,10 @@ class TradeApp(App[None]):
             (
                 f"{basename}_inventory{suffix}_{stamp}.csv",
                 inventory_to_csv(inventory_trends, items=self._state.items, locale=locale),
+            ),
+            (
+                f"{basename}_dashboard{suffix}_{stamp}.html",
+                dashboard_to_html(dashboard_data, title_text=f"anno-save-analyzer: {basename}"),
             ),
         ]
         written: list[Path] = []

--- a/tests/cli/test_title_resolver.py
+++ b/tests/cli/test_title_resolver.py
@@ -4,7 +4,11 @@ from anno_save_analyzer.cli._title import resolve_title
 from anno_save_analyzer.trade.models import GameTitle
 
 
-def test_resolve_title_prefers_explicit_value() -> None:
+def test_resolve_title_prefers_explicit_value_when_matching_extension() -> None:
+    assert resolve_title(Path("save.a7s"), GameTitle.ANNO_1800) is GameTitle.ANNO_1800
+
+
+def test_resolve_title_prefers_explicit_value_when_mismatching_extension() -> None:
     assert resolve_title(Path("save.a7s"), GameTitle.ANNO_117) is GameTitle.ANNO_117
 
 

--- a/tests/cli/test_title_resolver.py
+++ b/tests/cli/test_title_resolver.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from anno_save_analyzer.cli._title import resolve_title
+from anno_save_analyzer.trade.models import GameTitle
+
+
+def test_resolve_title_prefers_explicit_value() -> None:
+    assert resolve_title(Path("save.a7s"), GameTitle.ANNO_117) is GameTitle.ANNO_117
+
+
+def test_resolve_title_infers_from_extension_when_unspecified() -> None:
+    assert resolve_title(Path("save.a7s"), None) is GameTitle.ANNO_1800

--- a/tests/cli/test_trade.py
+++ b/tests/cli/test_trade.py
@@ -21,7 +21,7 @@ def _make_save(tmp_path: Path) -> Path:
         }
     )
     outer = wrap_as_outer([inner])
-    save = tmp_path / "fake.bin"
+    save = tmp_path / "fake.a8s"
     save.write_bytes(outer)
     return save
 
@@ -105,9 +105,9 @@ class TestTradeDiffCommand:
                 "passive": [],  # 2142 removed
             }
         )
-        before = tmp_path / "before.bin"
+        before = tmp_path / "before.a8s"
         before.write_bytes(wrap_as_outer([before_inner]))
-        after = tmp_path / "after.bin"
+        after = tmp_path / "after.a8s"
         after.write_bytes(wrap_as_outer([after_inner]))
         return before, after
 
@@ -161,7 +161,7 @@ class TestTradeDiffCommand:
     def test_diff_by_route_show_unchanged(self, tmp_path: Path) -> None:
         """same before/after で route 差分，show_unchanged で unchanged 行も出す．"""
         same_inner = make_inner_filedb({"route": [(7, 2088, 5, 0)]})
-        save = tmp_path / "same.bin"
+        save = tmp_path / "same.a8s"
         save.write_bytes(wrap_as_outer([same_inner]))
         result = runner.invoke(
             app,

--- a/tests/cli/test_tui_cmd.py
+++ b/tests/cli/test_tui_cmd.py
@@ -16,7 +16,7 @@ runner = CliRunner()
 
 def _make_save(tmp_path: Path) -> Path:
     inner = make_inner_filedb({"route": [(7, 2088, 5, 0)]})
-    save = tmp_path / "fake.bin"
+    save = tmp_path / "fake.a8s"
     save.write_bytes(wrap_as_outer([inner]))
     return save
 

--- a/tests/trade/test_analysis.py
+++ b/tests/trade/test_analysis.py
@@ -1,0 +1,144 @@
+"""trade.analysis の単体テスト．"""
+
+from __future__ import annotations
+
+from anno_save_analyzer.trade.analysis import (
+    IslandProductRunway,
+    compute_runways,
+    display_runway_rows,
+    shortage_list,
+    supply_demand_balance,
+)
+from anno_save_analyzer.trade.models import Item
+from anno_save_analyzer.trade.storage import IslandStorageTrend, PointSeries
+
+
+def _trend(island: str, guid: int, samples: tuple[int, ...]) -> IslandStorageTrend:
+    n = len(samples)
+    return IslandStorageTrend(
+        island_name=island,
+        product_guid=guid,
+        points=PointSeries(capacity=n, size=n, samples=samples),
+    )
+
+
+class TestIslandProductRunway:
+    def test_depleted_zero(self) -> None:
+        r = IslandProductRunway(island_name="A", product_guid=1, latest=0, slope_per_min=-1.0)
+        assert r.runway_min == 0.0
+        assert r.status == "depleted"
+
+    def test_growing_none(self) -> None:
+        r = IslandProductRunway(island_name="A", product_guid=1, latest=100, slope_per_min=1.0)
+        assert r.runway_min is None
+        assert r.status == "stable_or_growing"
+
+    def test_declining(self) -> None:
+        # 100 units, losing 2/min → 50 min runway
+        r = IslandProductRunway(island_name="A", product_guid=1, latest=100, slope_per_min=-2.0)
+        assert r.runway_min == 50.0
+        assert r.status == "warning"  # 10 <= 50 < 60
+
+    def test_critical_under_10min(self) -> None:
+        r = IslandProductRunway(island_name="A", product_guid=1, latest=5, slope_per_min=-1.0)
+        assert r.runway_min == 5.0
+        assert r.status == "critical"
+
+    def test_ok_over_60min(self) -> None:
+        r = IslandProductRunway(island_name="A", product_guid=1, latest=1000, slope_per_min=-1.0)
+        assert r.runway_min == 1000.0
+        assert r.status == "ok"
+
+
+class TestComputeRunways:
+    def test_sorted_by_runway_ascending(self) -> None:
+        trends = [
+            _trend("A", 1, (100, 99, 98)),  # slope = -1 → runway 98
+            _trend("B", 2, (50, 48, 46)),  # slope = -2 → runway 23
+            _trend("C", 3, (10, 20, 30)),  # growing → None
+            _trend("D", 4, (5, 4, 3)),  # slope = -1 → runway 3
+        ]
+        rws = compute_runways(trends)
+        assert [r.island_name for r in rws] == ["D", "B", "A", "C"]
+        # C は None で末尾
+        assert rws[-1].runway_min is None
+
+    def test_empty(self) -> None:
+        assert compute_runways([]) == []
+
+
+class TestShortageList:
+    def test_filters_by_threshold(self) -> None:
+        trends = [
+            _trend("A", 1, (10, 9, 8)),  # slope = -1, runway 8
+            _trend("B", 2, (100, 99, 98)),  # slope = -1, runway 98
+            _trend("C", 3, (1000, 999, 998)),  # slope = -1, runway 998 (ok)
+        ]
+        # threshold 120: A (8) と B (98) は不足，C (998) は OK
+        result = shortage_list(trends, threshold_min=120.0)
+        assert len(result) == 2
+        assert result[0].island_name == "A"
+        assert result[1].island_name == "B"
+
+    def test_threshold_none_returns_all_negative_slope(self) -> None:
+        trends = [
+            _trend("A", 1, (10, 9, 8)),
+            _trend("B", 2, (10, 20, 30)),  # growing → not in shortage
+        ]
+        result = shortage_list(trends, threshold_min=None)
+        assert len(result) == 1
+        assert result[0].island_name == "A"
+
+
+class TestSupplyDemandBalance:
+    def test_splits_surplus_and_deficit_by_slope_sign(self) -> None:
+        trends = [
+            _trend("A", 1, (10, 20, 30)),  # A 生産 (slope +10)
+            _trend("B", 1, (30, 20, 10)),  # B 消費 (slope -10)
+            _trend("C", 1, (5, 5, 5)),  # C 平坦 (slope 0)
+        ]
+        balances = supply_demand_balance(trends)
+        assert len(balances) == 1
+        b = balances[0]
+        assert b.product_guid == 1
+        assert b.surplus_islands == ("A",)
+        assert b.deficit_islands == ("B",)
+        # net = +10 + (-10) + 0 = 0
+        assert b.net_slope_per_min == 0.0
+
+    def test_sorted_by_net_descending(self) -> None:
+        trends = [
+            # good 1: net positive
+            _trend("A", 1, (10, 20, 30)),
+            # good 2: net negative
+            _trend("A", 2, (30, 20, 10)),
+        ]
+        balances = supply_demand_balance(trends)
+        assert [b.product_guid for b in balances] == [1, 2]
+
+
+class TestDisplayRunwayRows:
+    def test_renders_dict_rows(self) -> None:
+        rw = IslandProductRunway(
+            island_name="大阪民国", product_guid=2135, latest=5, slope_per_min=-1.0
+        )
+        items = {2135: Item(guid=2135, names={"en": "Iron", "ja": "鉄"})}
+        rows = display_runway_rows([rw], items, locale="ja")
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["island_name"] == "大阪民国"
+        assert r["product_name"] == "鉄"
+        assert r["runway_min"] == 5.0
+        assert r["status"] == "critical"
+
+    def test_missing_item_falls_back(self) -> None:
+        rw = IslandProductRunway(island_name="X", product_guid=9999, latest=10, slope_per_min=-1.0)
+        rows = display_runway_rows([rw], {}, locale="en")
+        # KeyError → fallback Good_9999
+        assert rows[0]["product_name"] == "Good_9999"
+
+    def test_none_runway_passes_through(self) -> None:
+        rw = IslandProductRunway(island_name="X", product_guid=1, latest=10, slope_per_min=1.0)
+        items = {1: Item(guid=1, names={"en": "X"})}
+        rows = display_runway_rows([rw], items)
+        assert rows[0]["runway_min"] is None

--- a/tests/trade/test_extract_a8s.py
+++ b/tests/trade/test_extract_a8s.py
@@ -1,7 +1,7 @@
-"""``.a7s`` / ``.a8s`` 拡張子経由の extract 動作テスト．
+"""RDA magic prefix 経由の extract dispatch テスト．
 
-実 RDA を組み立てるのは大掛かりなため，``extract_inner_filedb`` を monkeypatch
-で差し替えて ``load_outer_filedb`` の suffix branch（line 77）を踏ませる．
+``load_outer_filedb`` は拡張子でなく先頭 magic で RDA / zlib / bare を振り分ける．
+``extract_inner_filedb`` を monkeypatch で差し替えて RDA 分岐を踏ませる．
 """
 
 from __future__ import annotations
@@ -17,11 +17,14 @@ extract_mod = importlib.import_module("anno_save_analyzer.trade.extract")
 
 
 @pytest.mark.parametrize("suffix", [".a7s", ".a8s"])
-def test_a7s_a8s_suffix_dispatches_to_pipeline(
+def test_rda_magic_dispatches_to_pipeline(
     suffix: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """``Resource File V2.`` prefix を持つバイトは RDA extract 経由で展開される．"""
     fake_save = tmp_path / f"fake{suffix}"
-    fake_save.write_bytes(b"not a real RDA")
+    # 実 RDA の magic 先頭のみ偽装．以降は extract_inner_filedb を mock で置き換え
+    # して中身は見ないので残りはダミーで良い．
+    fake_save.write_bytes(b"Resource File V2.2" + b"\x00" * 100)
 
     expected = b"<<<inner FileDB synthetic>>>"
 
@@ -30,3 +33,13 @@ def test_a7s_a8s_suffix_dispatches_to_pipeline(
 
     monkeypatch.setattr(extract_mod, "extract_inner_filedb", _fake_extract)
     assert extract_mod.load_outer_filedb(fake_save) == expected
+
+
+def test_non_rda_falls_back_to_raw_bytes(tmp_path: Path) -> None:
+    """RDA magic が無ければ bare FileDB バイナリとしてそのまま返す．
+
+    テスト fixture / 手動展開済ファイルでも通るように．
+    """
+    fake_save = tmp_path / "fake.a8s"
+    fake_save.write_bytes(b"not a real RDA")
+    assert extract_mod.load_outer_filedb(fake_save) == b"not a real RDA"

--- a/tests/trade/test_html_export.py
+++ b/tests/trade/test_html_export.py
@@ -202,6 +202,8 @@ class TestDashboardToHtml:
         assert match is not None
         parsed = json.loads(match.group(1))
         assert parsed["meta"]["save"] == "before <!-- middle --> after"
+
+
 class TestTitleInference:
     """GameTitle.from_save_path (PR A の拡張子推定)．"""
 

--- a/tests/trade/test_html_export.py
+++ b/tests/trade/test_html_export.py
@@ -1,0 +1,202 @@
+"""trade.html_export の単体テスト．"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from anno_save_analyzer.trade.aggregate import by_item, by_route
+from anno_save_analyzer.trade.html_export import (
+    build_dashboard_data,
+    dashboard_to_html,
+)
+from anno_save_analyzer.trade.items import ItemDictionary
+from anno_save_analyzer.trade.models import (
+    GameTitle,
+    Item,
+    TradeEvent,
+    TradingPartner,
+)
+from anno_save_analyzer.trade.storage import IslandStorageTrend, PointSeries
+
+
+def _events() -> list[TradeEvent]:
+    items = {1010566: Item(guid=1010566, names={"en": "Oil", "ja": "石油"})}
+
+    def _ev(tick: int, amt: int, gold: int = 0) -> TradeEvent:
+        return TradeEvent(
+            timestamp_tick=tick,
+            item=items[1010566],
+            amount=amt,
+            total_price=gold,
+            session_id="0",
+            island_name="Osaka",
+            route_id="7",
+            route_name="Osaka-Tokyo",
+            partner=TradingPartner(id="route:7", display_name="Route #7", kind="route"),
+            source_method="history",
+        )
+
+    return [_ev(1000, 10), _ev(2000, -5, 50), _ev(3000, 20)]
+
+
+def _items_dict() -> ItemDictionary:
+    return ItemDictionary({1010566: Item(guid=1010566, names={"en": "Oil", "ja": "石油"})})
+
+
+def _trends() -> list[IslandStorageTrend]:
+    return [
+        IslandStorageTrend(
+            island_name="Osaka",
+            product_guid=1010566,
+            points=PointSeries(capacity=3, size=3, samples=(100, 80, 60)),
+        ),
+    ]
+
+
+class TestBuildDashboardData:
+    def test_shape(self) -> None:
+        events = _events()
+        items = _items_dict()
+        trends = _trends()
+        data = build_dashboard_data(
+            events=events,
+            item_summaries=by_item(events),
+            route_summaries=by_route(events),
+            inventory_trends=trends,
+            items=items,
+            title=GameTitle.ANNO_1800,
+            locale="ja",
+            save_name="test.a7s",
+        )
+        assert data["meta"]["title"] == "anno1800"
+        assert data["meta"]["save"] == "test.a7s"
+        assert data["meta"]["locale"] == "ja"
+        assert len(data["events"]) == 3
+        assert data["events"][0]["item_name"] == "石油"  # ja localised
+        assert any(t["island"] == "Osaka" for t in data["inventory"])
+        # slope = -20/min (100→80→60), so runway_min should exist
+        assert data["runways"]
+        assert data["shortages"]  # 60 units at -20/min → 3 min runway → critical
+        assert data["balances"][0]["net_slope_per_min"] < 0  # deficit
+
+    def test_minutes_ago_computed(self) -> None:
+        events = _events()
+        data = build_dashboard_data(
+            events=events,
+            item_summaries=by_item(events),
+            route_summaries=by_route(events),
+            inventory_trends=[],
+            items=_items_dict(),
+            title=GameTitle.ANNO_1800,
+            locale="en",
+        )
+        # newest event (tick=3000) should have min_ago=0.0
+        min_agos = [e["min_ago"] for e in data["events"]]
+        assert 0.0 in min_agos
+        # all finite
+        assert all(v is not None for v in min_agos)
+
+
+class TestDashboardToHtml:
+    def test_output_is_valid_html_with_embedded_json(self) -> None:
+        events = _events()
+        data = build_dashboard_data(
+            events=events,
+            item_summaries=by_item(events),
+            route_summaries=by_route(events),
+            inventory_trends=_trends(),
+            items=_items_dict(),
+            title=GameTitle.ANNO_1800,
+            locale="ja",
+            save_name="test.a7s",
+        )
+        out = dashboard_to_html(data)
+        assert out.startswith("<!DOCTYPE html>")
+        assert "<script" in out
+        # 埋め込み JSON が有効
+        match = re.search(
+            r'<script type="application/json" id="dashboard-data">(.*?)</script>',
+            out,
+            re.DOTALL,
+        )
+        assert match is not None
+        parsed = json.loads(match.group(1))
+        assert parsed["meta"]["save"] == "test.a7s"
+
+    def test_sections_present(self) -> None:
+        data = build_dashboard_data(
+            events=[],
+            item_summaries=[],
+            route_summaries=[],
+            inventory_trends=[],
+            items=_items_dict(),
+            title=GameTitle.ANNO_117,
+            locale="en",
+        )
+        out = dashboard_to_html(data)
+        for section_id in [
+            "overview",
+            "shortages",
+            "balance",
+            "inventory",
+            "items",
+            "routes",
+            "events",
+        ]:
+            assert f'id="{section_id}"' in out, f"missing section {section_id}"
+
+    def test_save_name_escaped_in_header(self) -> None:
+        """``<script>`` を save 名に突っ込んでも HTML escape される．
+
+        header は ``html.escape`` で `&lt;` に変換．script JSON 領域でも
+        ``</script>`` を ``<\\/script>`` に変換して DOM 早期終了を防ぐ．
+        """
+        data = build_dashboard_data(
+            events=[],
+            item_summaries=[],
+            route_summaries=[],
+            inventory_trends=[],
+            items=_items_dict(),
+            title=GameTitle.ANNO_1800,
+            locale="en",
+            save_name="<script>alert(1)</script>",
+        )
+        out = dashboard_to_html(data)
+        # header section は html.escape されとる
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+        # baseline は 3 個 (Plotly CDN / JSON data / inline logic) — save 名由来の
+        # 余分な ``</script>`` が JSON 領域に混入したら 4 個になる．escape してるので 3．
+        # template にも ``}})();\\n</script>`` が含まれるため JSON の外で 1 個増えるが
+        # 悪意のある save_name 入力でこれを増やさんことを確認する．
+        clean_data = build_dashboard_data(
+            events=[],
+            item_summaries=[],
+            route_summaries=[],
+            inventory_trends=[],
+            items=_items_dict(),
+            title=GameTitle.ANNO_1800,
+            locale="en",
+            save_name="normal",
+        )
+        clean_out = dashboard_to_html(clean_data)
+        assert out.count("</script>") == clean_out.count("</script>")
+
+
+class TestTitleInference:
+    """GameTitle.from_save_path (PR A の拡張子推定)．"""
+
+    def test_a7s_is_anno1800(self) -> None:
+        assert GameTitle.from_save_path("foo/bar.a7s") is GameTitle.ANNO_1800
+
+    def test_a8s_is_anno117(self) -> None:
+        assert GameTitle.from_save_path("/abs/baz.a8s") is GameTitle.ANNO_117
+
+    def test_upper_case_suffix(self) -> None:
+        assert GameTitle.from_save_path("BAR.A7S") is GameTitle.ANNO_1800
+
+    def test_unknown_extension_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="Cannot infer"):
+            GameTitle.from_save_path("foo.zip")

--- a/tests/trade/test_html_export.py
+++ b/tests/trade/test_html_export.py
@@ -182,7 +182,26 @@ class TestDashboardToHtml:
         clean_out = dashboard_to_html(clean_data)
         assert out.count("</script>") == clean_out.count("</script>")
 
-
+    def test_embedded_json_parses_with_html_comment_tokens_in_save_name(self) -> None:
+        data = build_dashboard_data(
+            events=[],
+            item_summaries=[],
+            route_summaries=[],
+            inventory_trends=[],
+            items=_items_dict(),
+            title=GameTitle.ANNO_1800,
+            locale="en",
+            save_name="before <!-- middle --> after",
+        )
+        out = dashboard_to_html(data)
+        match = re.search(
+            r'<script type="application/json" id="dashboard-data">(.*?)</script>',
+            out,
+            re.DOTALL,
+        )
+        assert match is not None
+        parsed = json.loads(match.group(1))
+        assert parsed["meta"]["save"] == "before <!-- middle --> after"
 class TestTitleInference:
     """GameTitle.from_save_path (PR A の拡張子推定)．"""
 


### PR DESCRIPTION
## Summary
書記長要望 3 件 (PR A スコープ):

### 1. HTML ダッシュボード export (``^O``)
``<basename>_dashboard_<stamp>.html`` を CSV 4 枚と同時に書き出す．Plotly (CDN) + sortable テーブル + 全 data JSON 埋め込みで 1 ファイル自己完結．ブラウザで開けばすぐ Excel コピペもできる．

### 2. 分析 primitives (``trade/analysis.py``)
- **枯渇残り分** (IslandProductRunway): ``latest / |slope_per_min|``．``status`` は depleted/critical/warning/ok/stable_or_growing．
- **不足物資リスト** (shortage_list): slope 負 + runway <= threshold．
- **需要供給バランス** (supply_demand_balance): 物資ごとの黒字/赤字島と net slope．

純関数．既存 StorageTrends で計算できる範囲のみ．人口 × 需要の DOM parser は **PR B** で対応予定．

### 3. 拡張子で自動判定 + --title optional 化
``.a7s`` → Anno 1800 / ``.a8s`` → Anno 117．``anno-save-analyzer trade list sample.a7s`` みたいに ``--title`` 無しで動く．明示指定も残してある．``load_outer_filedb`` は拡張子でなく先頭 magic で振り分け．

## セキュリティ
- embedded HTML テーブルは ``textContent`` / ``createElement`` のみで構築．save 由来の島名・ルート名・アイテム名を innerHTML 補間しない．
- embedded JSON ``</script>`` / ``<!--`` / ``-->`` を escape して script タグ早期終了を防ぐ．

## 効果 (実セーブ)
| | sample_anno1800.a7s |
|---|---|
| HTML サイズ | 3.2 MB |
| shortages (runway ≤ 120min) | 2,358 件 |
| balances | 206 物資 |

## カバレッジ
520 passed (+24)，branch coverage 98.7%

## Followup
- **PR B**: ``AreaPopulationManager`` / ``AreaWideNeedsManager`` / ``AreaResidenceConsumptionManager`` 等の新規 DOM parser + 人口連動分析 (需要構成 / 人口あたり消費量)．
- **#60**: save-time tick 基準化．
- **Anno 1800 の 120 サンプル時系列** 多セーブ合成．

## Test plan
- [ ] CI 緑
- [ ] 書記長環境で ``anno-save-analyzer tui sample.a7s`` (``--title`` 不要) 起動，``^O`` 後に ``*_dashboard_*.html`` がブラウザで正しく開く
- [ ] Shortages/Balance セクションに実データ載る