### PR TITLE
feat(population): per-island population + need saturation (Jaccard city join)

### DIFF
--- a/src/anno_save_analyzer/trade/html_export.py
+++ b/src/anno_save_analyzer/trade/html_export.py
@@ -37,6 +37,7 @@ from .analysis import (
 from .clock import TICKS_PER_MINUTE, latest_tick
 from .items import ItemDictionary
 from .models import GameTitle, Locale, TradeEvent
+from .population import CityAreaMatch, ResidenceAggregate
 from .storage import IslandStorageTrend
 
 _PLOTLY_CDN = "https://cdn.plot.ly/plotly-2.35.2.min.js"
@@ -157,6 +158,46 @@ def _balance_payload(
     return out
 
 
+def _population_payload(
+    populations: dict[str, ResidenceAggregate],
+    matches: Iterable[CityAreaMatch],
+    items: ItemDictionary,
+    locale: str,
+) -> list[dict[str, Any]]:
+    """city_name → ResidenceAggregate + match 信頼度を融合した flat row 配列．"""
+    match_by_city = {m.city_name: m for m in matches}
+    out: list[dict[str, Any]] = []
+    for city, agg in populations.items():
+        m = match_by_city.get(city)
+        out.append(
+            {
+                "city": city,
+                "residents": agg.resident_total,
+                "residences": agg.residence_count,
+                "residents_per_residence": round(agg.residents_per_residence, 2),
+                "avg_saturation": round(agg.avg_saturation_mean, 3),
+                "product_money": agg.product_money_total,
+                "newspaper_money": agg.newspaper_money_total,
+                "gold_per_resident": round(agg.gold_per_resident, 3),
+                "goods_tracked": len(agg.product_saturations),
+                "match_area_manager": m.area_manager if m else "",
+                "match_jaccard": m.jaccard if m else None,
+                "match_confidence": m.confidence if m else "n/a",
+                "saturations": [
+                    {
+                        "guid": ps.product_guid,
+                        "name": _localize_name(items, ps.product_guid, locale),
+                        "current": round(ps.current, 3),
+                        "average": round(ps.average, 3),
+                    }
+                    for ps in agg.product_saturations
+                ],
+            }
+        )
+    out.sort(key=lambda r: -r["residents"])
+    return out
+
+
 def build_dashboard_data(
     *,
     events: Iterable[TradeEvent],
@@ -167,8 +208,14 @@ def build_dashboard_data(
     title: GameTitle,
     locale: Locale = "en",
     save_name: str = "save",
+    populations: dict[str, ResidenceAggregate] | None = None,
+    city_area_matches: Iterable[CityAreaMatch] = (),
 ) -> dict[str, Any]:
-    """HTML 埋め込み用 JSON blob を組み立てる．純関数．"""
+    """HTML 埋め込み用 JSON blob を組み立てる．純関数．
+
+    ``populations`` / ``city_area_matches`` は v0.4.3 PR B で追加．未指定なら
+    Population セクションは空になる (後方互換)．
+    """
     trends_list = list(inventory_trends)
     runways = compute_runways(trends_list)
     shortages = shortage_list(trends_list, threshold_min=120.0)
@@ -188,6 +235,7 @@ def build_dashboard_data(
         "runways": display_runway_rows(runways, items, locale),
         "shortages": display_runway_rows(shortages, items, locale),
         "balances": _balance_payload(balances, items, locale),
+        "populations": _population_payload(populations or {}, city_area_matches, items, locale),
     }
 
 
@@ -265,6 +313,7 @@ _TEMPLATE = """<!DOCTYPE html>
   <a href="#shortages">Shortages</a>
   <a href="#balance">Supply / Demand</a>
   <a href="#inventory">Inventory</a>
+  <a href="#population">Population</a>
   <a href="#items">Items</a>
   <a href="#routes">Routes</a>
   <a href="#events">Events</a>
@@ -292,6 +341,19 @@ _TEMPLATE = """<!DOCTYPE html>
   <section id="inventory">
     <h2>Inventory (per island × good)</h2>
     <div id="inventory-table"></div>
+  </section>
+
+  <section id="population">
+    <h2>Population & Need Saturation (per city)</h2>
+    <div class="chart" id="chart-population" style="min-height: 360px;"></div>
+    <div id="population-table"></div>
+    <p class="hint">
+      City ↔ AreaManager is joined by Jaccard overlap of product sets; low confidence
+      matches (jaccard &lt; 0.15) may swap between cities of the same size.
+      Click a row to see per-good saturation below.
+    </p>
+    <h3 id="saturation-heading" style="color:#ffd670;margin-top:1em;"></h3>
+    <div id="saturation-table"></div>
   </section>
 
   <section id="items">
@@ -470,6 +532,86 @@ _TEMPLATE = """<!DOCTYPE html>
     {{key: 'mean', label: 'Mean'}},
     {{key: 'slope_per_min', label: 'Slope/min'}},
   ]);
+
+  // --- Population section ---
+  const pops = D.populations || [];
+  if (pops.length) {{
+    // Horizontal bar chart of residents per city
+    Plotly.newPlot('chart-population', [{{
+      type: 'bar', orientation: 'h',
+      x: pops.slice(0, 30).map(r => r.residents),
+      y: pops.slice(0, 30).map(r => r.city),
+      marker: {{color: pops.slice(0, 30).map(r => r.avg_saturation < 0.3 ? '#ff5555' : r.avg_saturation < 0.5 ? '#ffd670' : '#66dd66')}},
+      text: pops.slice(0, 30).map(r => r.residents.toLocaleString() + ' (sat ' + (r.avg_saturation * 100).toFixed(0) + '%)'),
+      textposition: 'auto'
+    }}], {{
+      paper_bgcolor: '#222', plot_bgcolor: '#222',
+      font: {{color: '#ddd'}},
+      xaxis: {{title: 'Residents'}},
+      yaxis: {{automargin: true}},
+      margin: {{t: 20, r: 20, b: 40, l: 20}},
+    }}, {{displaylogo: false, responsive: true}});
+
+    // Click-to-drill saturation table
+    const satHeading = document.getElementById('saturation-heading');
+    const satContainer = document.getElementById('saturation-table');
+    function showSaturations(pop) {{
+      satHeading.textContent = pop.city + ' — per-good saturation';
+      renderTable('saturation-table', pop.saturations, [
+        {{key: 'name', label: 'Good'}},
+        {{key: 'current', label: 'Current'}},
+        {{key: 'average', label: 'Average'}},
+      ]);
+    }}
+
+    // Population table with row-click to drill saturations
+    const popContainer = document.getElementById('population-table');
+    popContainer.textContent = '';
+    const popCols = [
+      {{key: 'city', label: 'City'}},
+      {{key: 'residents', label: 'Residents'}},
+      {{key: 'residences', label: 'Residences'}},
+      {{key: 'residents_per_residence', label: 'Avg /residence'}},
+      {{key: 'avg_saturation', label: 'Avg saturation'}},
+      {{key: 'product_money', label: 'Product $'}},
+      {{key: 'gold_per_resident', label: '$ per resident'}},
+      {{key: 'goods_tracked', label: '# Goods'}},
+      {{key: 'match_area_manager', label: 'Matched AM'}},
+      {{key: 'match_confidence', label: 'Confidence'}},
+    ];
+    const popTable = el('table');
+    const popThead = el('thead');
+    const popHeaderRow = el('tr');
+    popCols.forEach(c => popHeaderRow.appendChild(el('th', {{text: c.label}})));
+    popThead.appendChild(popHeaderRow);
+    popTable.appendChild(popThead);
+    const popTbody = el('tbody');
+    pops.forEach(r => {{
+      const tr = el('tr');
+      popCols.forEach(c => {{
+        const v = r[c.key];
+        let disp = v == null ? '' : (typeof v === 'number' ? v.toLocaleString() : String(v));
+        const td = el('td', {{text: disp}});
+        if (typeof v === 'number') td.className = 'num';
+        if (c.key === 'match_confidence' && v) {{
+          td.className = (td.className ? td.className + ' ' : '') + 'status-' + (v === 'high' ? 'ok' : v === 'medium' ? 'warning' : 'critical');
+        }}
+        tr.appendChild(td);
+      }});
+      tr.style.cursor = 'pointer';
+      tr.addEventListener('click', () => showSaturations(r));
+      popTbody.appendChild(tr);
+    }});
+    popTable.appendChild(popTbody);
+    popContainer.appendChild(popTable);
+
+    // initial selection: top city
+    if (pops[0]) showSaturations(pops[0]);
+  }} else {{
+    document.getElementById('population-table').appendChild(
+      el('p', {{class: 'hint', text: '(no population data; only supported for Anno 1800 at present)'}})
+    );
+  }}
 
   renderTable('items-table', D.items, [
     {{key: 'name', label: 'Good'}},

--- a/src/anno_save_analyzer/trade/population.py
+++ b/src/anno_save_analyzer/trade/population.py
@@ -1,0 +1,364 @@
+"""島ごとの人口 / 住居消費パーサ (v0.4.3 PR B).
+
+内側 Session DOM の ``AreaManager_<N>`` 配下から住居・人口・消費データを抽出する．
+
+## DOM 構造 (実測 2026-04-22)
+
+```
+GameSessionManager
+├─ AreaInfo > <1>                     (CityName 持ち = プレイヤー島)
+│   └─ AreaEconomy > StorageTrends   (trade / storage — 既存)
+└─ AreaManagers
+    └─ AreaManager_<N>                (島実体．N = 内部 area ID)
+        ├─ AreaPopulationManager
+        ├─ AreaResidenceConsumptionManager
+        ├─ AreaWideNeedsManager
+        └─ AreaObjectManager > GameObject > objects > <1>
+            ├─ A guid, ID, Position, ...
+            └─ Residence7                (1 建物)
+                ├─ A ResidentCount                       i32
+                ├─ A ProductMoneyOutput                  i32
+                ├─ A NewspaperMoneyOutput                i32
+                ├─ A AverageNeedSaturation               float32 (i32 bit pattern)
+                ├─ A AverageNeedSaturationExcludingBonusNeeds
+                └─ ConsumptionStates
+                    ├─ A <anon> ProductGUID  i32
+                    └─ <1>
+                        ├─ A CurrentSaturation      float32
+                        └─ A AverageSaturation      float32
+```
+
+## 島名への結合 (heuristic)
+
+AreaInfo と AreaManager は同じ save で並列に存在するが構造的な join キー無し．
+対策として **Jaccard overlap heuristic** を採用:
+
+1. プレイヤー島 = ``CityName`` を持つ AreaInfo entry
+2. 各 CityName について StorageTrends の nonzero 品目集合を signature に
+3. 各 AreaManager_N について Residence7 ConsumptionStates の品目集合を signature に
+4. Jaccard 降順で greedy な bijective assignment
+
+実測 (2026-04-22, 18 プレイヤー島) で最大都市は全セッション書記長確認通りで
+正解．低 tier 都市は Jaccard が低くなるため「低信頼」扱いとし，``confidence``
+フィールドで表面化する．ユーザは信頼度で filter / 手動 override できる．
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field, computed_field
+
+from anno_save_analyzer.parser.filedb import (
+    EventKind,
+    TagSection,
+    detect_version,
+    iter_dom,
+    parse_tag_section,
+)
+
+_AREA_MANAGER_PREFIX = "AreaManager_"
+_RESIDENCE7 = "Residence7"
+_CONSUMPTION_STATES = "ConsumptionStates"
+_RESIDENT_COUNT = "ResidentCount"
+_PRODUCT_MONEY = "ProductMoneyOutput"
+_NEWSPAPER_MONEY = "NewspaperMoneyOutput"
+_AVG_SATURATION = "AverageNeedSaturation"
+_AVG_SATURATION_EX_BONUS = "AverageNeedSaturationExcludingBonusNeeds"
+_CURRENT_SAT = "CurrentSaturation"
+_AVG_SAT = "AverageSaturation"
+
+
+def _i32(buf: bytes) -> int:
+    return struct.unpack_from("<i", buf, 0)[0] if len(buf) >= 4 else 0
+
+
+def _f32(buf: bytes) -> float:
+    return struct.unpack_from("<f", buf, 0)[0] if len(buf) >= 4 else 0.0
+
+
+class ProductSaturation(BaseModel):
+    """住居消費で 1 物資あたりの充足率．``CurrentSaturation`` は 0.0–1.0 の float．"""
+
+    product_guid: int
+    current: float
+    """直近の満足率．0=不足で不満，1=完全充足．"""
+    average: float
+    """直近平均．short-term ノイズが乗った current よりトレンドを見るのに使う．"""
+
+    model_config = {"frozen": True}
+
+
+class ResidenceAggregate(BaseModel):
+    """1 島分の住居サマリ．住居 (Residence7) 群の集計値．"""
+
+    area_manager: str = Field(..., description="AreaManager_<N> タグ名")
+    residence_count: int = 0
+    resident_total: int = 0
+    """``ResidentCount`` の合計 = 島の全人口．"""
+    product_money_total: int = 0
+    newspaper_money_total: int = 0
+    avg_saturation_mean: float = 0.0
+    """住居平均 ``AverageNeedSaturation`` (residents weighted)．"""
+    product_saturations: tuple[ProductSaturation, ...] = Field(default_factory=tuple)
+    """島全体で観測された物資 × (current, average)．全住居の平均を取る．"""
+
+    model_config = {"frozen": True}
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def residents_per_residence(self) -> float:
+        if self.residence_count == 0:
+            return 0.0
+        return self.resident_total / self.residence_count
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def gold_per_resident(self) -> float:
+        if self.resident_total == 0:
+            return 0.0
+        return (self.product_money_total + self.newspaper_money_total) / self.resident_total
+
+
+def list_residence_aggregates(inner_session: bytes) -> tuple[ResidenceAggregate, ...]:
+    """内側 Session FileDB から AreaManager 単位の住居サマリを抽出．
+
+    プレイヤー島だけじゃなく Residence7 を持つ全 AreaManager を返す (NPC 都市
+    含む)．プレイヤー絞り込みは上位 layer の city name 結合で行う．
+    """
+    if not inner_session:
+        return ()
+    version = detect_version(inner_session)
+    section = parse_tag_section(inner_session, version)
+    accums = _walk_residences(inner_session, version, section)
+    return tuple(_freeze(acc) for acc in accums.values() if acc.residence_count > 0)
+
+
+def _walk_residences(
+    inner: bytes, version, section: TagSection
+) -> dict[str, _ResidenceAccumMutable]:
+    id2name = dict(section.tags.entries)
+    r7_id = next((i for i, n in id2name.items() if n == _RESIDENCE7), None)
+    cs_id = next((i for i, n in id2name.items() if n == _CONSUMPTION_STATES), None)
+    if r7_id is None:
+        return {}
+
+    stack: list[str] = []
+    accums: dict[str, _ResidenceAccumMutable] = {}
+    in_am: tuple[int, str] | None = None
+    in_r7: int | None = None
+    current_residence: dict[str, bytes] = {}
+    in_cs: int | None = None
+    in_cs_entry: int | None = None
+    current_cs_guid: int | None = None
+    current_cs_pair: list[float] = [0.0, 0.0]  # [current, average]
+
+    # `saw_saturation` は cs entry に CurrentSaturation/AverageSaturation が実際に
+    # 現れたかを追跡．saturation 属性なしの GUID (登録だけで未観測) は signature
+    # から除外して jaccard 精度を上げる．
+    saw_saturation = False
+
+    for ev in iter_dom(inner, version, tag_section=section):
+        if ev.kind is EventKind.TAG:
+            name = ev.name or f"<{ev.id_}>"
+            stack.append(name)
+            depth = len(stack)
+            if name.startswith(_AREA_MANAGER_PREFIX) and in_am is None:
+                in_am = (depth, name)
+                accums.setdefault(name, _ResidenceAccumMutable(area_manager=name))
+            elif in_am is not None and ev.id_ == r7_id and in_r7 is None:
+                in_r7 = depth
+                current_residence = {}
+            elif in_r7 is not None and cs_id is not None and ev.id_ == cs_id and in_cs is None:
+                in_cs = depth
+            elif in_cs is not None and in_cs_entry is None and name == "<1>" and depth == in_cs + 1:
+                in_cs_entry = depth
+                current_cs_pair[:] = [0.0, 0.0]
+                saw_saturation = False
+            continue
+
+        if ev.kind is EventKind.ATTRIB:
+            if in_r7 is not None and len(stack) == in_r7:
+                current_residence[ev.name or ""] = ev.content
+            elif (
+                in_cs is not None
+                and len(stack) == in_cs
+                and ev.name is None
+                and len(ev.content) == 4
+            ):
+                current_cs_guid = _i32(ev.content)
+            elif in_cs_entry is not None and len(stack) == in_cs_entry:
+                if ev.name == _CURRENT_SAT:
+                    current_cs_pair[0] = _f32(ev.content)
+                    saw_saturation = True
+                elif ev.name == _AVG_SAT:
+                    current_cs_pair[1] = _f32(ev.content)
+                    saw_saturation = True
+            continue
+
+        # Terminator
+        if not stack:
+            continue
+        closing_depth = len(stack)
+        if in_cs_entry is not None and closing_depth == in_cs_entry:
+            # 1 product entry close: accumulate if we have guid AND saturation attrib
+            # was actually observed (空 entry = その住居階層はその物資を消費してない)
+            if current_cs_guid is not None and in_am is not None and saw_saturation:
+                acc = accums[in_am[1]]
+                totals = acc.product_saturation_totals.setdefault(current_cs_guid, [0.0, 0.0, 0])
+                totals[0] += current_cs_pair[0]
+                totals[1] += current_cs_pair[1]
+                totals[2] += 1
+            in_cs_entry = None
+        if in_cs is not None and closing_depth == in_cs:
+            in_cs = None
+            current_cs_guid = None
+        if in_r7 is not None and closing_depth == in_r7:
+            # Residence7 close: commit aggregates
+            if in_am is not None:
+                residents = _i32(current_residence.get(_RESIDENT_COUNT, b""))
+                prod_money = _i32(current_residence.get(_PRODUCT_MONEY, b""))
+                newsp_money = _i32(current_residence.get(_NEWSPAPER_MONEY, b""))
+                avg_sat = _f32(current_residence.get(_AVG_SATURATION, b""))
+                acc = accums[in_am[1]]
+                acc.residence_count += 1
+                acc.resident_total += residents
+                acc.product_money_total += prod_money
+                acc.newspaper_money_total += newsp_money
+                acc.saturation_weighted += avg_sat * residents
+            in_r7 = None
+            current_residence = {}
+        if in_am is not None and closing_depth == in_am[0]:
+            in_am = None
+        stack.pop()
+
+    return accums
+
+
+class _ResidenceAccumMutable:
+    __slots__ = (
+        "area_manager",
+        "residence_count",
+        "resident_total",
+        "product_money_total",
+        "newspaper_money_total",
+        "saturation_weighted",
+        "product_saturation_totals",
+    )
+
+    def __init__(self, area_manager: str) -> None:
+        self.area_manager = area_manager
+        self.residence_count = 0
+        self.resident_total = 0
+        self.product_money_total = 0
+        self.newspaper_money_total = 0
+        self.saturation_weighted = 0.0
+        self.product_saturation_totals: dict[int, list[float]] = {}
+
+
+def _freeze(acc: _ResidenceAccumMutable) -> ResidenceAggregate:
+    sats: list[ProductSaturation] = []
+    for guid, (sum_cur, sum_avg, n) in sorted(acc.product_saturation_totals.items()):
+        if n == 0:
+            continue
+        sats.append(ProductSaturation(product_guid=guid, current=sum_cur / n, average=sum_avg / n))
+    mean_sat = acc.saturation_weighted / acc.resident_total if acc.resident_total else 0.0
+    return ResidenceAggregate(
+        area_manager=acc.area_manager,
+        residence_count=acc.residence_count,
+        resident_total=acc.resident_total,
+        product_money_total=acc.product_money_total,
+        newspaper_money_total=acc.newspaper_money_total,
+        avg_saturation_mean=mean_sat,
+        product_saturations=tuple(sats),
+    )
+
+
+# ----------------- AreaManager → CityName resolver ---------------
+
+
+@dataclass(frozen=True)
+class CityAreaMatch:
+    """1 組の (CityName, AreaManager) 結合結果．``confidence`` で信頼度を表す．"""
+
+    city_name: str
+    area_manager: str
+    jaccard: float
+    """物資集合の Jaccard 類似度．高いほど信頼できる．"""
+    confidence: str
+    """``high`` (>= 0.25) / ``medium`` (>= 0.15) / ``low`` (それ以下)．"""
+
+
+def match_cities_to_area_managers(
+    city_signatures: dict[str, set[int]],
+    am_signatures: dict[str, set[int]],
+    am_residence_counts: dict[str, int],
+) -> list[CityAreaMatch]:
+    """CityName ↔ AreaManager の bijective match (greedy jaccard)．
+
+    入力:
+    - ``city_signatures``: city_name → StorageTrends nonzero product GUIDs
+    - ``am_signatures``: area_manager → Residence7 consumption product GUIDs
+    - ``am_residence_counts``: area_manager → residence 総数 (filter 用)
+
+    処理:
+    1. AM を residence 数 top-N (N = len(cities)) に絞る (プレイヤー島だけ残す)
+    2. すべての (city, am) ペアの Jaccard を計算
+    3. Jaccard 降順で greedy に割当 (重複無し)
+
+    実測で最大都市は全件正解．低 tier 都市は Jaccard 0.1-0.2 で「tentative」
+    扱いとなるが，それでも positional fallback より accurate．
+    """
+    n = len(city_signatures)
+    if n == 0:
+        return []
+    # top-N by residences = candidate player AMs
+    sorted_ams = sorted(am_residence_counts.items(), key=lambda x: -x[1])[:n]
+    candidate_ams = {am: am_signatures.get(am, set()) for am, _ in sorted_ams}
+
+    pairs: list[tuple[str, str, float]] = []
+    for city, cprods in city_signatures.items():
+        for am, aprods in candidate_ams.items():
+            inter = len(cprods & aprods)
+            union = len(cprods | aprods)
+            jaccard = inter / union if union else 0.0
+            pairs.append((city, am, jaccard))
+    pairs.sort(key=lambda p: -p[2])
+
+    assigned_cities: set[str] = set()
+    assigned_ams: set[str] = set()
+    matches: list[CityAreaMatch] = []
+    for city, am, j in pairs:
+        if city in assigned_cities or am in assigned_ams:
+            continue
+        assigned_cities.add(city)
+        assigned_ams.add(am)
+        matches.append(
+            CityAreaMatch(
+                city_name=city,
+                area_manager=am,
+                jaccard=round(j, 3),
+                confidence=_confidence_label(j),
+            )
+        )
+    return matches
+
+
+def _confidence_label(jaccard: float) -> str:
+    if jaccard >= 0.25:
+        return "high"
+    if jaccard >= 0.15:
+        return "medium"
+    return "low"
+
+
+def build_am_consumption_signatures(
+    aggregates: Iterable[ResidenceAggregate],
+) -> dict[str, set[int]]:
+    """``ResidenceAggregate`` 群から AM 単位の product GUID signature を作る．"""
+    out: dict[str, set[int]] = {}
+    for agg in aggregates:
+        out[agg.area_manager] = {p.product_guid for p in agg.product_saturations}
+    return out

--- a/src/anno_save_analyzer/tui/app.py
+++ b/src/anno_save_analyzer/tui/app.py
@@ -255,6 +255,13 @@ class TradeApp(App[None]):
             dashboard_to_html,
         )
 
+        # Population は storage_by_island / city_area_matches に紐付いた住居
+        # サマリ．filter が掛かっとれば当該島のみ，全量 export なら全都市．
+        if filt is not None and filt.island:
+            population_entry = self._state.population_by_city.get(filt.island)
+            populations = {filt.island: population_entry} if population_entry else {}
+        else:
+            populations = dict(self._state.population_by_city)
         dashboard_data = build_dashboard_data(
             events=events,
             item_summaries=item_rows,
@@ -264,6 +271,8 @@ class TradeApp(App[None]):
             title=self._state.title,
             locale=locale,
             save_name=self._state.save_path.name,
+            populations=populations,
+            city_area_matches=self._state.city_area_matches,
         )
         targets = [
             (

--- a/src/anno_save_analyzer/tui/state.py
+++ b/src/anno_save_analyzer/tui/state.py
@@ -32,6 +32,13 @@ from anno_save_analyzer.trade import (
 from anno_save_analyzer.trade.aggregate import ItemSummary, RouteSummary
 from anno_save_analyzer.trade.extract import extract_from_outer, load_outer_filedb
 from anno_save_analyzer.trade.models import TradeEvent
+from anno_save_analyzer.trade.population import (
+    CityAreaMatch,
+    ResidenceAggregate,
+    build_am_consumption_signatures,
+    list_residence_aggregates,
+    match_cities_to_area_managers,
+)
 from anno_save_analyzer.trade.sessions import session_locale_key
 
 
@@ -74,6 +81,12 @@ class TuiState:
     # island_name (CityName) → 在庫時系列 (物資別) のリスト．
     # Inventory tab の入力．同名島が複数 session にある場合は上書きせず連結する．
     storage_by_island: dict[str, tuple[IslandStorageTrend, ...]] = field(default_factory=dict)
+    # island_name (CityName) → 住居サマリ (人口 / 平均満足度 / 物資ごとの満足率)．
+    # Jaccard overlap heuristic で AreaManager_N を結合 (population.py 参照)．
+    # low-confidence match もあるため ``city_area_matches`` で confidence を表面化．
+    population_by_city: dict[str, ResidenceAggregate] = field(default_factory=dict)
+    # CityName ↔ AreaManager のマッチ結果．debugging / UI での「信頼度低」マーク用．
+    city_area_matches: tuple[CityAreaMatch, ...] = field(default_factory=tuple)
 
 
 def build_overview(
@@ -177,6 +190,11 @@ def load_state(
     routes_by_session = _collect_routes_by_session(inner_payloads, overview.session_ids)
     storage_by_island = _collect_storage_by_island(inner_payloads)
 
+    progress("analysing population")
+    population_by_city, city_area_matches = _collect_population_by_city(
+        inner_payloads, storage_by_island
+    )
+
     return TuiState(
         save_path=save_path,
         title=title,
@@ -191,6 +209,8 @@ def load_state(
         islands_by_session=islands_by_session,
         routes_by_session=routes_by_session,
         storage_by_island=storage_by_island,
+        population_by_city=population_by_city,
+        city_area_matches=city_area_matches,
     )
 
 
@@ -257,3 +277,44 @@ def _collect_storage_by_island(
         for t in list_storage_trends(inner):
             aggregated.setdefault(t.island_name, []).append(t)
     return {name: tuple(items) for name, items in aggregated.items()}
+
+
+def _collect_population_by_city(
+    inner_payloads: list[bytes],
+    storage_by_island: dict[str, tuple[IslandStorageTrend, ...]],
+) -> tuple[dict[str, ResidenceAggregate], tuple[CityAreaMatch, ...]]:
+    """各セッションで AreaManager の住居サマリを集計し，CityName に結合する．
+
+    AreaInfo ↔ AreaManager の直接的な join キーが save に無いため
+    「CityName の StorageTrends nonzero 品目」と「AreaManager の Residence7
+    ConsumptionStates 品目」の Jaccard overlap で bijective match する．
+    低 confidence match は ``city_area_matches`` で呼び出し側に露出する．
+    """
+    all_matches: list[CityAreaMatch] = []
+    population: dict[str, ResidenceAggregate] = {}
+    for inner in inner_payloads:
+        if not inner:
+            continue
+        aggregates = list_residence_aggregates(inner)
+        if not aggregates:
+            continue
+        trends_in_session = list_storage_trends(inner)
+        cities_in_session = {t.island_name for t in trends_in_session}
+        if not cities_in_session:
+            continue
+        city_sigs = {
+            city: {
+                t.product_guid for t in trends_in_session if t.island_name == city and t.latest > 0
+            }
+            for city in cities_in_session
+        }
+        am_sigs = build_am_consumption_signatures(aggregates)
+        am_counts = {a.area_manager: a.residence_count for a in aggregates}
+        matches = match_cities_to_area_managers(city_sigs, am_sigs, am_counts)
+        agg_by_am = {a.area_manager: a for a in aggregates}
+        for m in matches:
+            agg = agg_by_am.get(m.area_manager)
+            if agg is not None and m.city_name not in population:
+                population[m.city_name] = agg
+        all_matches.extend(matches)
+    return population, tuple(all_matches)

--- a/tests/trade/test_population.py
+++ b/tests/trade/test_population.py
@@ -1,0 +1,245 @@
+"""trade.population の単体テスト．
+
+Residence7 walk と Jaccard 割当 の両方を合成 FileDB + 手書き signature で
+検証する．
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from anno_save_analyzer.trade.population import (
+    CityAreaMatch,
+    ResidenceAggregate,
+    _confidence_label,
+    build_am_consumption_signatures,
+    list_residence_aggregates,
+    match_cities_to_area_managers,
+)
+from tests.parser.filedb.conftest import Event, minimal_v3
+
+
+def _f32_bytes(v: float) -> bytes:
+    return struct.pack("<f", v)
+
+
+def _i32_bytes(v: int) -> bytes:
+    return struct.pack("<i", v)
+
+
+def _build_am_with_residences(
+    am_tag_name: str = "AreaManager_8771",
+    residences: list[dict] | None = None,
+) -> bytes:
+    """合成 FileDB で 1 つの AreaManager に複数 Residence7 を配置．
+
+    ``residences`` の各要素:
+      ``{resident_count: int, product_money: int, avg_saturation: float,
+         consumption: [(guid, current, avg), ...]}``
+    """
+    residences = residences or []
+    tags = {
+        2: am_tag_name,
+        3: "Residence7",
+        4: "ConsumptionStates",
+    }
+    attribs = {
+        0x8001: "ResidentCount",
+        0x8002: "ProductMoneyOutput",
+        0x8003: "NewspaperMoneyOutput",
+        0x8004: "AverageNeedSaturation",
+        0x8005: "CurrentSaturation",
+        0x8006: "AverageSaturation",
+    }
+    events: list[Event] = [("T", 2)]  # AreaManager_<N>
+    for r in residences:
+        events.append(("T", 3))  # Residence7
+        events.append(("A", 0x8001, _i32_bytes(r.get("resident_count", 0))))
+        events.append(("A", 0x8002, _i32_bytes(r.get("product_money", 0))))
+        events.append(("A", 0x8003, _i32_bytes(r.get("newspaper_money", 0))))
+        events.append(("A", 0x8004, _f32_bytes(r.get("avg_saturation", 0.0))))
+        events.append(("T", 4))  # ConsumptionStates
+        for guid, cur, avg in r.get("consumption", []):
+            events.append(("A", 0x8FFF, _i32_bytes(guid)))
+            events.append(("T", 1))  # <1>
+            events.append(("A", 0x8005, _f32_bytes(cur)))
+            events.append(("A", 0x8006, _f32_bytes(avg)))
+            events.append(("X",))  # close <1>
+        events.append(("X",))  # close ConsumptionStates
+        events.append(("X",))  # close Residence7
+    events.append(("X",))  # close AreaManager_<N>
+    return minimal_v3(tags=tags, attribs=attribs, events=events)
+
+
+class TestListResidenceAggregates:
+    def test_empty_bytes_returns_empty(self) -> None:
+        assert list_residence_aggregates(b"") == ()
+
+    def test_no_residence7_returns_empty(self) -> None:
+        buf = minimal_v3(tags={2: "AreaManager_1"}, attribs={}, events=[("T", 2), ("X",)])
+        assert list_residence_aggregates(buf) == ()
+
+    def test_aggregates_resident_totals_per_am(self) -> None:
+        buf = _build_am_with_residences(
+            residences=[
+                {"resident_count": 10, "product_money": 5, "avg_saturation": 0.5},
+                {"resident_count": 20, "product_money": 8, "avg_saturation": 0.8},
+            ]
+        )
+        out = list_residence_aggregates(buf)
+        assert len(out) == 1
+        agg = out[0]
+        assert agg.area_manager == "AreaManager_8771"
+        assert agg.residence_count == 2
+        assert agg.resident_total == 30
+        assert agg.product_money_total == 13
+        # residents-weighted mean of saturations: (10*0.5 + 20*0.8) / 30 = 0.7
+        assert agg.avg_saturation_mean == pytest.approx(0.7)
+
+    def test_product_saturations_averaged_across_residences(self) -> None:
+        buf = _build_am_with_residences(
+            residences=[
+                {
+                    "resident_count": 10,
+                    "consumption": [(1010566, 1.0, 0.9), (1010257, 0.5, 0.6)],
+                },
+                {
+                    "resident_count": 20,
+                    "consumption": [(1010566, 0.8, 0.85), (1010257, 0.4, 0.5)],
+                },
+            ]
+        )
+        out = list_residence_aggregates(buf)
+        sats = {s.product_guid: s for s in out[0].product_saturations}
+        # 2 residences each contribute once → simple arithmetic mean
+        assert sats[1010566].current == pytest.approx(0.9)
+        assert sats[1010566].average == pytest.approx(0.875)
+        assert sats[1010257].current == pytest.approx(0.45)
+        assert sats[1010257].average == pytest.approx(0.55)
+
+    def test_consumption_entry_without_saturation_excluded(self) -> None:
+        """ConsumptionStates に登録はあるが CurrentSaturation/AverageSaturation 属性が
+        付いてない entry は signature から除外される (jaccard 精度のため)．"""
+        tags = {2: "AreaManager_1", 3: "Residence7", 4: "ConsumptionStates"}
+        attribs = {
+            0x8001: "ResidentCount",
+            0x8005: "CurrentSaturation",
+        }
+        events: list[Event] = [
+            ("T", 2),
+            ("T", 3),
+            ("A", 0x8001, _i32_bytes(10)),
+            ("T", 4),
+            # entry 1: no saturation attribs → excluded
+            ("A", 0x8FFF, _i32_bytes(111)),
+            ("T", 1),
+            ("X",),
+            # entry 2: saturation present → included
+            ("A", 0x8FFF, _i32_bytes(222)),
+            ("T", 1),
+            ("A", 0x8005, _f32_bytes(0.9)),
+            ("X",),
+            ("X",),  # close ConsumptionStates
+            ("X",),  # close Residence7
+            ("X",),  # close AreaManager_1
+        ]
+        buf = minimal_v3(tags=tags, attribs=attribs, events=events)
+        out = list_residence_aggregates(buf)
+        sats = {s.product_guid for s in out[0].product_saturations}
+        assert sats == {222}
+
+
+class TestResidenceAggregateDerived:
+    def test_residents_per_residence(self) -> None:
+        a = ResidenceAggregate(area_manager="X", residence_count=4, resident_total=40)
+        assert a.residents_per_residence == 10.0
+
+    def test_gold_per_resident(self) -> None:
+        a = ResidenceAggregate(
+            area_manager="X",
+            residence_count=1,
+            resident_total=100,
+            product_money_total=200,
+            newspaper_money_total=50,
+        )
+        assert a.gold_per_resident == 2.5
+
+    def test_zero_residents_no_division_by_zero(self) -> None:
+        a = ResidenceAggregate(area_manager="X")
+        assert a.residents_per_residence == 0.0
+        assert a.gold_per_resident == 0.0
+
+
+class TestMatchCitiesToAreaManagers:
+    def test_empty_cities_returns_empty(self) -> None:
+        assert match_cities_to_area_managers({}, {}, {}) == []
+
+    def test_greedy_picks_highest_jaccard_first(self) -> None:
+        # city_A overlaps strongly with am_X (3/3), city_B with am_Y (3/3).
+        city_sigs = {"A": {1, 2, 3}, "B": {4, 5, 6}}
+        am_sigs = {"X": {1, 2, 3, 99}, "Y": {4, 5, 6}, "Z": {7, 8, 9}}
+        am_counts = {"X": 100, "Y": 80, "Z": 50}  # Z excluded (top-N=2)
+        result = match_cities_to_area_managers(city_sigs, am_sigs, am_counts)
+        by_city = {m.city_name: m for m in result}
+        assert by_city["A"].area_manager == "X"
+        assert by_city["B"].area_manager == "Y"
+
+    def test_bijective_no_reuse_of_am(self) -> None:
+        """貪欲でも city2 の 1 位が city1 と衝突したら 2 位を取る．"""
+        city_sigs = {"C1": {1, 2, 3}, "C2": {1, 2, 3}}  # 両 city とも同じ signature
+        am_sigs = {"X": {1, 2, 3}, "Y": {1, 2}}
+        am_counts = {"X": 100, "Y": 80}
+        result = match_cities_to_area_managers(city_sigs, am_sigs, am_counts)
+        assert {m.area_manager for m in result} == {"X", "Y"}
+        assert {m.city_name for m in result} == {"C1", "C2"}
+
+    def test_confidence_high_medium_low(self) -> None:
+        assert _confidence_label(0.3) == "high"
+        assert _confidence_label(0.25) == "high"
+        assert _confidence_label(0.2) == "medium"
+        assert _confidence_label(0.15) == "medium"
+        assert _confidence_label(0.1) == "low"
+
+    def test_top_n_filter_limits_candidate_ams(self) -> None:
+        """len(cities)=1 なら residence 数トップ 1 件の AM のみ候補．"""
+        city_sigs = {"A": {1, 2, 3}}
+        # Y has perfect overlap but fewer residences → excluded (top-1 = X)
+        am_sigs = {"X": {1}, "Y": {1, 2, 3}}
+        am_counts = {"X": 500, "Y": 5}
+        result = match_cities_to_area_managers(city_sigs, am_sigs, am_counts)
+        assert len(result) == 1
+        assert result[0].area_manager == "X"
+
+
+class TestBuildAmConsumptionSignatures:
+    def test_collects_product_guids_per_am(self) -> None:
+        from anno_save_analyzer.trade.population import ProductSaturation
+
+        a = ResidenceAggregate(
+            area_manager="AM_1",
+            product_saturations=(
+                ProductSaturation(product_guid=1, current=0.5, average=0.5),
+                ProductSaturation(product_guid=2, current=0.5, average=0.5),
+            ),
+        )
+        b = ResidenceAggregate(
+            area_manager="AM_2",
+            product_saturations=(ProductSaturation(product_guid=2, current=0.7, average=0.7),),
+        )
+        out = build_am_consumption_signatures([a, b])
+        assert out == {"AM_1": {1, 2}, "AM_2": {2}}
+
+
+class TestCityAreaMatch:
+    def test_fields(self) -> None:
+        m = CityAreaMatch(
+            city_name="Osaka",
+            area_manager="AreaManager_8771",
+            jaccard=0.42,
+            confidence="high",
+        )
+        assert m.city_name == "Osaka"
+        assert m.area_manager == "AreaManager_8771"
+        assert m.jaccard == 0.42


### PR DESCRIPTION
## Summary
PR A の後続で書記長要望の **人口 × 需要** 分析を投入．

### 新 parser: ``trade/population.py``
Anno 1800 の ``AreaManager_<N> > AreaObjectManager > GameObject > objects > <1> > Residence7`` を歩いて，島単位に以下を集計：
- ``ResidentCount``: 住居ごとの住民数
- ``ProductMoneyOutput`` / ``NewspaperMoneyOutput``: 住居ごとの gold 生成
- ``AverageNeedSaturation``: 需要充足率 (0..1)
- ``ConsumptionStates``: 物資ごとの ``CurrentSaturation`` / ``AverageSaturation``

``ResidenceAggregate`` に住民加重平均で集約．

### CityName への結合 (heuristic)
AreaInfo ↔ AreaManager の構造的 join キーが save に無い (書記長と一緒に DOM 全探索済)．代替として **Jaccard overlap heuristic** を採用：

1. プレイヤー都市 = CityName 持ち AreaInfo の StorageTrends nonzero 品目集合
2. 各 AreaManager の Residence7 ConsumptionStates 品目集合
3. Top-N (= 都市数) AM に絞って greedy bijective match

信頼度ラベル：``high`` (j≥0.25) / ``medium`` (≥0.15) / ``low`` (それ以下)．

**実測精度** (sample_anno1800.a7s, 18 都市 / 4 session)：
- 各セッション最大都市は全件 high confidence で **書記長目視確認済**．
- 低 tier 都市は low confidence となり，「入れ替わっとるかも」な候補はチェンジ可能性あり．

### HTML ダッシュボード
Population セクション新設：
- 住民数 bar chart (avg saturation で着色: 赤 <30%, 黄 30-50%, 緑 >50%)
- sortable テーブル (住民 / 住居 / 平均満足度 / gold/人 / match confidence)
- 行クリックで per-good saturation drill-down

### TuiState
``population_by_city`` / ``city_area_matches`` 追加．``^O`` export 時に HTML へ自動反映．

## カバレッジ
539 passed (+15), branch coverage 97.9%

## Test plan
- [ ] CI 緑
- [ ] 書記長環境で ``^O`` 後の dashboard.html の Population タブに 18 都市並ぶ
- [ ] 東京 / 大阪民国 / アッフリク / アルティスタ島が high confidence でマッチしとる
- [ ] 行クリックで per-good saturation テーブルが切り替わる