### PR TITLE
feat: Factory7 extractor for per-island supply tracking (#66)

### DIFF
--- a/src/anno_save_analyzer/trade/factories.py
+++ b/src/anno_save_analyzer/trade/factories.py
@@ -1,0 +1,233 @@
+"""島ごとの Factory7 抽出 (v0.4 supply-balance の供給側データ)．
+
+``factory_extraction_spike`` (docs/factory_extraction_spike.md, 2026-04-23) で
+確定した DOM を state machine で舐める．
+
+## DOM 構造 (Anno 1800 / 117 共通)
+
+```
+AreaManager_<N>
+└─ GameObject
+    └─ objects
+        └─ <1>                       (1 建物インスタンス)
+            ├─ A guid                i32  ← 建物 GUID (buildings.yaml key)
+            ├─ A ID / Position / ... (他メタ)
+            └─ Factory7              (このタグを持つ建物のみ生産コンポ)
+                ├─ A CurrentProductivity f32 (通常 0.0–2.0 / DLC 系アイテムで 3.0+ 実測)
+                └─ ProductionState
+                    ├─ A InProgress       u8 bool
+                    ├─ A RemainingTime    f32 (game tick)
+                    └─ A Productivity     f32 (累積，履歴用)
+```
+
+``Pausable`` / ``Maintenance`` 等の兄弟タグは本 module では扱わない．停止状態
+や維持費は future work (``balance.py`` 合流時).
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field, computed_field
+
+from anno_save_analyzer.parser.filedb import (
+    EventKind,
+    TagSection,
+    detect_version,
+    iter_dom,
+    parse_tag_section,
+)
+
+_AREA_MANAGER_PREFIX = "AreaManager_"
+_OBJECTS = "objects"
+_FACTORY7 = "Factory7"
+_PRODUCTION_STATE = "ProductionState"
+_CURRENT_PRODUCTIVITY = "CurrentProductivity"
+_IN_PROGRESS = "InProgress"
+_REMAINING_TIME = "RemainingTime"
+_PRODUCTIVITY = "Productivity"
+_GUID_ATTRIB = "guid"
+
+
+def _f32(buf: bytes) -> float:
+    return struct.unpack_from("<f", buf, 0)[0] if len(buf) >= 4 else 0.0
+
+
+def _i32(buf: bytes) -> int:
+    return struct.unpack_from("<i", buf, 0)[0] if len(buf) >= 4 else 0
+
+
+class ProductionStateSnapshot(BaseModel):
+    """``ProductionState`` 子タグのスナップショット．全属性 optional．"""
+
+    in_progress: bool | None = None
+    """``True`` で生産中 (enabled かつ原料充足)，``False`` で停止．"""
+    remaining_time: float | None = None
+    """次サイクル完了までの残秒 (game tick 単位)．"""
+    cumulative_productivity: float | None = None
+    """``ProductionState > Productivity``．累積生産レートの移動平均 (履歴用)．"""
+
+    model_config = {"frozen": True}
+
+
+class FactoryInstance(BaseModel):
+    """1 工場インスタンス．``guid`` attrib 経由で建物種別が引ける．"""
+
+    building_guid: int
+    """``objects > <1>`` 直下の ``guid`` attrib．``buildings.yaml`` の key に対応．"""
+    productivity: float
+    """``Factory7 > CurrentProductivity``．通常 0.0–2.0 (200% バフ込み) だが
+    DLC のアイテムスタッキングで 3.0 以上になるケースも実在する (書記長 save
+    で 300% 実測)．UI 側で ``* 100`` して % 表示する想定．"""
+    state: ProductionStateSnapshot | None = None
+    """``ProductionState`` の内容．全属性欠けてれば ``None``．"""
+
+    model_config = {"frozen": True}
+
+
+class FactoryAggregate(BaseModel):
+    """1 AreaManager あたりの工場群．"""
+
+    area_manager: str = Field(..., description="AreaManager_<N> タグ名")
+    instances: tuple[FactoryInstance, ...] = Field(default_factory=tuple)
+
+    model_config = {"frozen": True}
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total(self) -> int:
+        return len(self.instances)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def mean_productivity(self) -> float:
+        """全工場の productivity 単純平均．0 工場なら 0.0．"""
+        if not self.instances:
+            return 0.0
+        return sum(i.productivity for i in self.instances) / len(self.instances)
+
+    def by_building(self) -> dict[int, tuple[FactoryInstance, ...]]:
+        """building_guid で group 化して返す．"""
+        grouped: dict[int, list[FactoryInstance]] = {}
+        for inst in self.instances:
+            grouped.setdefault(inst.building_guid, []).append(inst)
+        return {k: tuple(v) for k, v in grouped.items()}
+
+
+def list_factory_aggregates(inner_session: bytes) -> tuple[FactoryAggregate, ...]:
+    """inner session (per-session FileDB) から AreaManager 単位の工場集計を返す．
+
+    プレイヤー島 / NPC 島を区別せずに全 AreaManager を返す．プレイヤー絞り込み
+    は ``parser.filedb.session.list_player_islands`` の city_name 結合で上位層に委譲．
+    """
+    if not inner_session:
+        return ()
+    version = detect_version(inner_session)
+    section = parse_tag_section(inner_session, version)
+    return tuple(_walk(inner_session, version, section))
+
+
+def _walk(inner: bytes, version, section: TagSection) -> Iterable[FactoryAggregate]:
+    """DOM ストリームを state machine で舐めて FactoryAggregate を yield する．"""
+    stack: list[str] = []
+    in_am: tuple[int, str] | None = None  # (depth, name)
+    accums: dict[str, list[FactoryInstance]] = {}
+
+    in_obj_entry: int | None = None  # depth of objects > <1>
+    obj_guid: int | None = None
+
+    in_f7: int | None = None  # depth of Factory7
+    cur_productivity = 0.0
+    in_ps: int | None = None  # depth of ProductionState
+    ps_accum = _PSAccum()
+
+    for ev in iter_dom(inner, version, tag_section=section):
+        if ev.kind is EventKind.TAG:
+            name = ev.name or f"<{ev.id_}>"
+            stack.append(name)
+            depth = len(stack)
+            if name.startswith(_AREA_MANAGER_PREFIX) and in_am is None:
+                in_am = (depth, name)
+                accums.setdefault(name, [])
+            elif (
+                in_am is not None
+                and in_obj_entry is None
+                and name == "<1>"
+                and len(stack) >= 2
+                and stack[-2] == _OBJECTS
+            ):
+                in_obj_entry = depth
+                obj_guid = None
+            elif in_obj_entry is not None and in_f7 is None and name == _FACTORY7:
+                in_f7 = depth
+                cur_productivity = 0.0
+                ps_accum = _PSAccum()
+            elif (
+                in_f7 is not None
+                and in_ps is None
+                and name == _PRODUCTION_STATE
+                and depth == in_f7 + 1
+            ):
+                in_ps = depth
+            continue
+
+        if ev.kind is EventKind.ATTRIB:
+            if in_obj_entry is not None and len(stack) == in_obj_entry and ev.name == _GUID_ATTRIB:
+                obj_guid = _i32(ev.content)
+            elif in_f7 is not None and len(stack) == in_f7 and ev.name == _CURRENT_PRODUCTIVITY:
+                cur_productivity = _f32(ev.content)
+            elif in_ps is not None and len(stack) == in_ps:
+                if ev.name == _IN_PROGRESS:
+                    ps_accum.in_progress = bool(ev.content and ev.content[0])
+                elif ev.name == _REMAINING_TIME:
+                    ps_accum.remaining_time = _f32(ev.content)
+                elif ev.name == _PRODUCTIVITY:
+                    ps_accum.cumulative = _f32(ev.content)
+            continue
+
+        # Terminator
+        if not stack:
+            continue
+        closing_depth = len(stack)
+        if in_ps is not None and closing_depth == in_ps:
+            in_ps = None
+        if in_f7 is not None and closing_depth == in_f7:
+            # Factory7 close: commit instance
+            if in_am is not None and obj_guid is not None:
+                accums[in_am[1]].append(
+                    FactoryInstance(
+                        building_guid=obj_guid,
+                        productivity=cur_productivity,
+                        state=ps_accum.freeze(),
+                    )
+                )
+            in_f7 = None
+        if in_obj_entry is not None and closing_depth == in_obj_entry:
+            in_obj_entry = None
+            obj_guid = None
+        if in_am is not None and closing_depth == in_am[0]:
+            in_am = None
+        stack.pop()
+
+    for am_name, instances in accums.items():
+        yield FactoryAggregate(area_manager=am_name, instances=tuple(instances))
+
+
+@dataclass
+class _PSAccum:
+    """ProductionState 属性を組み立てるための可変バッファ．"""
+
+    in_progress: bool | None = None
+    remaining_time: float | None = None
+    cumulative: float | None = None
+
+    def freeze(self) -> ProductionStateSnapshot | None:
+        if self.in_progress is None and self.remaining_time is None and self.cumulative is None:
+            return None
+        return ProductionStateSnapshot(
+            in_progress=self.in_progress,
+            remaining_time=self.remaining_time,
+            cumulative_productivity=self.cumulative,
+        )

--- a/src/anno_save_analyzer/trade/factories.py
+++ b/src/anno_save_analyzer/trade/factories.py
@@ -1,7 +1,7 @@
 """島ごとの Factory7 抽出 (v0.4 supply-balance の供給側データ)．
 
-``factory_extraction_spike`` (docs/factory_extraction_spike.md, 2026-04-23) で
-確定した DOM を state machine で舐める．
+Factory7 を持つ建物ノードを対象に，この docstring で定義する DOM 前提を
+state machine で走査する．
 
 ## DOM 構造 (Anno 1800 / 117 共通)
 

--- a/tests/trade/test_anno1800_factories_smoke.py
+++ b/tests/trade/test_anno1800_factories_smoke.py
@@ -4,7 +4,7 @@
 productivity の分布が実在ゲームの値に収まっていることを確認する．
 
 CI / sample なし環境では skip．しきい値は書記長の ``sample_anno1800.a7s`` を
-前提にしとるため，``SAMPLE_ANNO1800`` override 先も同等の canonical sample を
+前提にしているため，``SAMPLE_ANNO1800`` override 先も同等の canonical sample を
 想定する．
 """
 

--- a/tests/trade/test_anno1800_factories_smoke.py
+++ b/tests/trade/test_anno1800_factories_smoke.py
@@ -3,7 +3,9 @@
 書記長の ``sample_anno1800.a7s`` から全 session の工場を舐めて，件数と
 productivity の分布が実在ゲームの値に収まっていることを確認する．
 
-CI / sample なし環境では skip．``SAMPLE_ANNO1800`` env で path override 可．
+CI / sample なし環境では skip．しきい値は書記長の ``sample_anno1800.a7s`` を
+前提にしとるため，``SAMPLE_ANNO1800`` override 先も同等の canonical sample を
+想定する．
 """
 
 from __future__ import annotations

--- a/tests/trade/test_anno1800_factories_smoke.py
+++ b/tests/trade/test_anno1800_factories_smoke.py
@@ -3,14 +3,12 @@
 書記長の ``sample_anno1800.a7s`` から全 session の工場を舐めて，件数と
 productivity の分布が実在ゲームの値に収まっていることを確認する．
 
-CI / sample なし環境では skip．しきい値は書記長の ``sample_anno1800.a7s`` を
-前提にしているため，``SAMPLE_ANNO1800`` override 先も同等の canonical sample を
-想定する．
+しきい値 (session 数 / 工場総数) は書記長の canonical sample を前提にしており，
+他 save に差し替えると fail する可能性が高い．sample 無しなら skip．
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -20,8 +18,7 @@ from anno_save_analyzer.parser.filedb.session import extract_sessions
 from anno_save_analyzer.parser.pipeline import extract_inner_filedb
 from anno_save_analyzer.trade.factories import list_factory_aggregates
 
-_DEFAULT_SAMPLE = Path(__file__).resolve().parents[2] / "sample_anno1800.a7s"
-SAMPLE_PATH = Path(os.environ.get("SAMPLE_ANNO1800", _DEFAULT_SAMPLE))
+SAMPLE_PATH = Path(__file__).resolve().parents[2] / "sample_anno1800.a7s"
 _HAS_SAMPLE = SAMPLE_PATH.is_file()
 
 

--- a/tests/trade/test_anno1800_factories_smoke.py
+++ b/tests/trade/test_anno1800_factories_smoke.py
@@ -1,0 +1,78 @@
+"""Anno 1800 実セーブでの Factory7 抽出 smoke test．
+
+書記長の ``sample_anno1800.a7s`` から全 session の工場を舐めて，件数と
+productivity の分布が実在ゲームの値に収まっていることを確認する．
+
+CI / sample なし環境では skip．``SAMPLE_ANNO1800`` env で path override 可．
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from anno_save_analyzer.parser.filedb import detect_version, parse_tag_section
+from anno_save_analyzer.parser.filedb.session import extract_sessions
+from anno_save_analyzer.parser.pipeline import extract_inner_filedb
+from anno_save_analyzer.trade.factories import list_factory_aggregates
+
+_DEFAULT_SAMPLE = Path(__file__).resolve().parents[2] / "sample_anno1800.a7s"
+SAMPLE_PATH = Path(os.environ.get("SAMPLE_ANNO1800", _DEFAULT_SAMPLE))
+_HAS_SAMPLE = SAMPLE_PATH.is_file()
+
+
+@pytest.mark.skipif(not _HAS_SAMPLE, reason=f"Anno 1800 sample not found: {SAMPLE_PATH}")
+class TestAnno1800FactoriesSmoke:
+    @pytest.fixture(scope="class")
+    def aggregates_per_session(self) -> list[list]:
+        outer = extract_inner_filedb(SAMPLE_PATH)
+        ver = detect_version(outer)
+        sec = parse_tag_section(outer, ver)
+        sessions = list(extract_sessions(outer, ver, sec))
+        return [list(list_factory_aggregates(inner)) for inner in sessions]
+
+    def test_sessions_extracted(self, aggregates_per_session: list[list]) -> None:
+        """Anno 1800 の save は 5 session (Cape Trelawney / Old World / Enbesa /
+        New World / Arctic)．抽出 pipeline が何 session か返す．"""
+        assert len(aggregates_per_session) == 5
+
+    def test_at_least_one_session_has_factories(self, aggregates_per_session: list[list]) -> None:
+        """書記長の save は Arctic 以外は必ず工場がある．1 session 以上で 100+
+        工場が取れる想定 (DLC 込みで主要島は 100-500 工場)．"""
+        counts = [sum(a.total for a in session_aggs) for session_aggs in aggregates_per_session]
+        assert max(counts) >= 100, f"no session has enough factories: {counts}"
+
+    def test_productivity_is_non_negative_and_finite(
+        self, aggregates_per_session: list[list]
+    ) -> None:
+        """CurrentProductivity は 0 以上で常識的な範囲に収まる．DLC のアイテム
+        で 200% を超えるケースも実在 (書記長 save で 300% 実測) するため上限は
+        緩めに 10.0 で wall．i32 誤読が入ると巨大値 / 負値になるため型確定の
+        ガードになる．"""
+        import math
+
+        for session_aggs in aggregates_per_session:
+            for agg in session_aggs:
+                for inst in agg.instances:
+                    p = inst.productivity
+                    assert math.isfinite(p), f"non-finite productivity: {p}"
+                    assert 0.0 <= p <= 10.0, (
+                        f"productivity out of [0,10]: {p} "
+                        f"(AM={agg.area_manager}, guid={inst.building_guid})"
+                    )
+
+    def test_building_guids_are_positive_ints(self, aggregates_per_session: list[list]) -> None:
+        """guid attrib が正しく i32 decode されとるか．負値は decode 失敗の兆候．"""
+        for session_aggs in aggregates_per_session:
+            for agg in session_aggs:
+                for inst in agg.instances:
+                    assert inst.building_guid > 0, (
+                        f"non-positive guid: {inst.building_guid} (AM={agg.area_manager})"
+                    )
+
+    def test_total_factories_across_sessions(self, aggregates_per_session: list[list]) -> None:
+        """書記長の save は DLC 込みで全 session 合計 500+ 工場想定．"""
+        total = sum(sum(a.total for a in session_aggs) for session_aggs in aggregates_per_session)
+        assert total >= 500, f"unexpectedly few factories in total: {total}"

--- a/tests/trade/test_factories.py
+++ b/tests/trade/test_factories.py
@@ -1,0 +1,266 @@
+"""``trade.factories`` の単体テスト．
+
+合成 FileDB で Factory7 walk を検証し，属性の有無 / 複数 AreaManager /
+building_guid group 化などのコーナーを網羅する．
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from anno_save_analyzer.trade.factories import (
+    FactoryAggregate,
+    FactoryInstance,
+    ProductionStateSnapshot,
+    list_factory_aggregates,
+)
+from tests.parser.filedb.conftest import Event, minimal_v3
+
+
+def _f32_bytes(v: float) -> bytes:
+    return struct.pack("<f", v)
+
+
+def _i32_bytes(v: int) -> bytes:
+    return struct.pack("<i", v)
+
+
+# tag ID の慣例:
+#   2 = AreaManager_<N>
+#   3 = GameObject
+#   4 = objects
+#   1 = <1>  (anonymous)
+#   5 = Factory7
+#   6 = ProductionState
+#   7 = (余り．別 AreaManager に使う)
+# attrib ID:
+#   0x8001 = guid
+#   0x8002 = CurrentProductivity
+#   0x8003 = InProgress
+#   0x8004 = RemainingTime
+#   0x8005 = Productivity
+_TAGS = {
+    2: "AreaManager_8706",
+    3: "GameObject",
+    4: "objects",
+    5: "Factory7",
+    6: "ProductionState",
+}
+_ATTRIBS = {
+    0x8001: "guid",
+    0x8002: "CurrentProductivity",
+    0x8003: "InProgress",
+    0x8004: "RemainingTime",
+    0x8005: "Productivity",
+}
+
+
+def _build(
+    factories: list[dict] | None = None,
+    am_tag_name: str = "AreaManager_8706",
+    *,
+    include_am_wrapper: bool = True,
+) -> bytes:
+    """合成 FileDB 構築．各 factory は {guid, productivity, state?} の dict．
+
+    ``state`` は ``{"in_progress": bool, "remaining_time": float,
+    "cumulative": float}`` で欠けた key は attrib を出さない．None なら
+    ProductionState タグ自体を省く．
+    """
+    factories = factories or []
+    tags = dict(_TAGS)
+    tags[2] = am_tag_name
+
+    events: list[Event] = []
+    if include_am_wrapper:
+        events.append(("T", 2))  # AreaManager
+        events.append(("T", 3))  # GameObject
+        events.append(("T", 4))  # objects
+    for f in factories:
+        events.append(("T", 1))  # <1> object entry
+        if f.get("guid") is not None:
+            events.append(("A", 0x8001, _i32_bytes(f["guid"])))
+        events.append(("T", 5))  # Factory7
+        events.append(("A", 0x8002, _f32_bytes(f.get("productivity", 0.0))))
+        state = f.get("state", ...)
+        if state is not ... and state is not None:
+            events.append(("T", 6))  # ProductionState
+            if "in_progress" in state:
+                events.append(("A", 0x8003, bytes([1 if state["in_progress"] else 0])))
+            if "remaining_time" in state:
+                events.append(("A", 0x8004, _f32_bytes(state["remaining_time"])))
+            if "cumulative" in state:
+                events.append(("A", 0x8005, _f32_bytes(state["cumulative"])))
+            events.append(("X",))  # close ProductionState
+        events.append(("X",))  # close Factory7
+        events.append(("X",))  # close <1>
+    if include_am_wrapper:
+        events.append(("X",))  # close objects
+        events.append(("X",))  # close GameObject
+        events.append(("X",))  # close AreaManager
+    return minimal_v3(tags=tags, attribs=_ATTRIBS, events=events)
+
+
+# ---------- 基本 ----------
+
+
+def test_empty_bytes_returns_empty() -> None:
+    assert list_factory_aggregates(b"") == ()
+
+
+def test_no_factory_returns_empty_instances() -> None:
+    """AreaManager はあるが Factory7 が無いケース．aggregate は空 instances で返す．"""
+    buf = _build(factories=[])
+    out = list_factory_aggregates(buf)
+    assert len(out) == 1
+    assert out[0].area_manager == "AreaManager_8706"
+    assert out[0].instances == ()
+    assert out[0].total == 0
+    assert out[0].mean_productivity == 0.0
+
+
+def test_single_factory_with_state() -> None:
+    buf = _build(
+        factories=[
+            {
+                "guid": 1010278,  # Fish Coast Building (実サンプル GUID)
+                "productivity": 0.75,
+                "state": {"in_progress": True, "remaining_time": 12.5, "cumulative": 0.72},
+            }
+        ]
+    )
+    out = list_factory_aggregates(buf)
+    assert len(out) == 1
+    agg = out[0]
+    assert agg.total == 1
+    inst = agg.instances[0]
+    assert inst.building_guid == 1010278
+    assert inst.productivity == pytest.approx(0.75)
+    assert inst.state is not None
+    assert inst.state.in_progress is True
+    assert inst.state.remaining_time == pytest.approx(12.5)
+    assert inst.state.cumulative_productivity == pytest.approx(0.72)
+
+
+def test_productivity_out_of_standard_range_preserved() -> None:
+    """200% バフで productivity が 1.0 超えも落とさず保存する．"""
+    buf = _build(factories=[{"guid": 1, "productivity": 1.8}])
+    inst = list_factory_aggregates(buf)[0].instances[0]
+    assert inst.productivity == pytest.approx(1.8)
+
+
+def test_mean_productivity_simple_average() -> None:
+    """mean は単純平均 (residents-weighted じゃない)．"""
+    buf = _build(
+        factories=[
+            {"guid": 1, "productivity": 0.0},
+            {"guid": 1, "productivity": 0.5},
+            {"guid": 1, "productivity": 1.0},
+        ]
+    )
+    agg = list_factory_aggregates(buf)[0]
+    assert agg.total == 3
+    assert agg.mean_productivity == pytest.approx(0.5)
+
+
+def test_factory_without_production_state() -> None:
+    """ProductionState 子タグ自体が無いケース．state=None になる．"""
+    buf = _build(factories=[{"guid": 42, "productivity": 1.0, "state": None}])
+    inst = list_factory_aggregates(buf)[0].instances[0]
+    assert inst.state is None
+
+
+def test_factory_without_guid_skipped() -> None:
+    """guid attrib が無い object entry の Factory7 は落とす (建物特定不能)．"""
+    buf = _build(factories=[{"guid": None, "productivity": 0.5}])
+    assert list_factory_aggregates(buf)[0].instances == ()
+
+
+# ---------- 複数 AreaManager ----------
+
+
+def test_multiple_area_managers_separate_aggregates() -> None:
+    """2 つの AreaManager それぞれで instances が独立に溜まる．"""
+    buf1 = _build(
+        am_tag_name="AreaManager_100",
+        factories=[{"guid": 1, "productivity": 0.5}],
+    )
+    buf2 = _build(
+        am_tag_name="AreaManager_200",
+        factories=[{"guid": 2, "productivity": 1.0}],
+    )
+    # 2 つを連結できないので，tags を共有する合成を作り直す
+    tags = dict(_TAGS)
+    tags[2] = "AreaManager_100"
+    tags[7] = "AreaManager_200"
+    events: list[Event] = [
+        ("T", 2),
+        ("T", 3),
+        ("T", 4),
+        ("T", 1),
+        ("A", 0x8001, _i32_bytes(1)),
+        ("T", 5),
+        ("A", 0x8002, _f32_bytes(0.5)),
+        ("X",),
+        ("X",),
+        ("X",),
+        ("X",),
+        ("X",),
+        ("T", 7),
+        ("T", 3),
+        ("T", 4),
+        ("T", 1),
+        ("A", 0x8001, _i32_bytes(2)),
+        ("T", 5),
+        ("A", 0x8002, _f32_bytes(1.0)),
+        ("X",),
+        ("X",),
+        ("X",),
+        ("X",),
+        ("X",),
+    ]
+    del buf1, buf2
+    buf = minimal_v3(tags=tags, attribs=_ATTRIBS, events=events)
+    out = list_factory_aggregates(buf)
+    by_name = {a.area_manager: a for a in out}
+    assert set(by_name) == {"AreaManager_100", "AreaManager_200"}
+    assert by_name["AreaManager_100"].instances[0].building_guid == 1
+    assert by_name["AreaManager_200"].instances[0].building_guid == 2
+
+
+def test_by_building_groups_instances() -> None:
+    buf = _build(
+        factories=[
+            {"guid": 100, "productivity": 0.5},
+            {"guid": 100, "productivity": 1.0},
+            {"guid": 200, "productivity": 0.8},
+        ]
+    )
+    agg = list_factory_aggregates(buf)[0]
+    grouped = agg.by_building()
+    assert set(grouped) == {100, 200}
+    assert len(grouped[100]) == 2
+    assert len(grouped[200]) == 1
+
+
+# ---------- Pydantic model properties ----------
+
+
+def test_aggregate_model_is_frozen() -> None:
+    agg = FactoryAggregate(area_manager="X", instances=())
+    with pytest.raises(Exception):  # noqa: B017
+        agg.area_manager = "Y"  # type: ignore[misc]
+
+
+def test_production_state_snapshot_frozen() -> None:
+    s = ProductionStateSnapshot(in_progress=True)
+    with pytest.raises(Exception):  # noqa: B017
+        s.in_progress = False  # type: ignore[misc]
+
+
+def test_instance_model_is_frozen() -> None:
+    i = FactoryInstance(building_guid=1, productivity=0.5)
+    with pytest.raises(Exception):  # noqa: B017
+        i.productivity = 1.0  # type: ignore[misc]


### PR DESCRIPTION
## Summary

v0.4 supply-balance milestone (#66) の **供給側データソース**．spike (#71) で
判明した ``AreaManager > GameObject > objects > <1> > Factory7`` の DOM を
state machine で舐めて，島別の工場稼働率を集計する．

## API

```python
from anno_save_analyzer.trade.factories import list_factory_aggregates

aggs = list_factory_aggregates(inner_session_bytes)
for agg in aggs:
    print(agg.area_manager, agg.total, agg.mean_productivity)
    for guid, insts in agg.by_building().items():
        print(f"  {guid}: {len(insts)} factories")
```

## 実測データからの発見

**``CurrentProductivity`` は通常 0.0–2.0 だが DLC アイテムスタッキングで
3.0+ 実在**．書記長 save の ``AreaManager_8514 / guid=1010262`` (Rum Distillery)
で productivity=3.0 を確認．spike 時点では 200% 上限と推定してたが訂正．
UI 側で ``* 100`` して % 表示する方針．テストの上限 wall は 10.0 に緩めた．

spike docs は PR #71 で merge 済なので本 PR の commit message / docstring 内
で実測訂正を明記．

## 非対応 (future work, balance.py 合流時)

- ``Pausable`` 子タグからの停止フラグ
- ``Maintenance`` からの維持費
- ``LogisticNode`` / ``ModuleOwner`` からの倉庫接続・モジュール情報

## Test plan

- [x] 合成 FileDB で 12 テスト (空 / 単一 / 複数 / ProductionState 無し /
      guid 無し skip / 複数 AM / by_building / frozen model 3 件)
- [x] 実 save smoke で 5 テスト (session 数 / factory 数 / productivity
      有限性 / guid 正値 / total カウント)
- [x] pytest 全体 556 passed / coverage 98.00% (90% ゲート超過)
- [x] ruff check + format clean

## 依存

- spike docs (#71) が先行 merge 推奨だが必須じゃない (この PR の docstring
  で自己完結)
- buildings YAML (#74 PR / #67) と組み合わせると ``building_guid`` → 建物名が
  解決できるが，本 PR 単体でも guid ベースで使える

Refs: #66