### PR TITLE
feat(population): per-tier residence breakdown via BuildingDictionary (#64)

### DIFF
--- a/src/anno_save_analyzer/trade/population.py
+++ b/src/anno_save_analyzer/trade/population.py
@@ -59,7 +59,10 @@ from anno_save_analyzer.parser.filedb import (
     parse_tag_section,
 )
 
+from .buildings import BuildingDictionary
+
 _AREA_MANAGER_PREFIX = "AreaManager_"
+_OBJECTS = "objects"
 _RESIDENCE7 = "Residence7"
 _CONSUMPTION_STATES = "ConsumptionStates"
 _RESIDENT_COUNT = "ResidentCount"
@@ -69,6 +72,11 @@ _AVG_SATURATION = "AverageNeedSaturation"
 _AVG_SATURATION_EX_BONUS = "AverageNeedSaturationExcludingBonusNeeds"
 _CURRENT_SAT = "CurrentSaturation"
 _AVG_SAT = "AverageSaturation"
+_GUID_ATTRIB = "guid"
+_UNKNOWN_TIER = "unknown"
+"""``BuildingDictionary`` で tier が未判定の Residence を集計するキー．Arctic
+/ Colony 系など assets.xml の internal name が ``residence_tier0N`` 命名規則
+から外れてるケースが該当する．"""
 
 
 def _i32(buf: bytes) -> int:
@@ -91,6 +99,22 @@ class ProductSaturation(BaseModel):
     model_config = {"frozen": True}
 
 
+class TierSummary(BaseModel):
+    """1 住居階層 (Farmer / Worker / ...) 分の集計．島別 tier breakdown の要素．"""
+
+    tier: str
+    """``farmer`` / ``worker`` / ``artisan`` / ``engineer`` / ``investor`` /
+    ``jornaleros`` / ``obreros`` / ``unknown``．``unknown`` は
+    ``BuildingDictionary`` で tier 判定できなかった Residence (Arctic / Colony
+    系など命名規則外)．"""
+    residence_count: int = 0
+    resident_total: int = 0
+    avg_saturation_mean: float = 0.0
+    """住居平均 ``AverageNeedSaturation`` (residents weighted)．"""
+
+    model_config = {"frozen": True}
+
+
 class ResidenceAggregate(BaseModel):
     """1 島分の住居サマリ．住居 (Residence7) 群の集計値．"""
 
@@ -104,6 +128,9 @@ class ResidenceAggregate(BaseModel):
     """住居平均 ``AverageNeedSaturation`` (residents weighted)．"""
     product_saturations: tuple[ProductSaturation, ...] = Field(default_factory=tuple)
     """島全体で観測された物資 × (current, average)．全住居の平均を取る．"""
+    tier_breakdown: tuple[TierSummary, ...] = Field(default_factory=tuple)
+    """Farmer / Worker / ... 別の内訳．``list_residence_aggregates`` に
+    ``buildings`` を渡した時のみ populate．渡さない場合は空 tuple．"""
 
     model_config = {"frozen": True}
 
@@ -122,22 +149,33 @@ class ResidenceAggregate(BaseModel):
         return (self.product_money_total + self.newspaper_money_total) / self.resident_total
 
 
-def list_residence_aggregates(inner_session: bytes) -> tuple[ResidenceAggregate, ...]:
+def list_residence_aggregates(
+    inner_session: bytes,
+    *,
+    buildings: BuildingDictionary | None = None,
+) -> tuple[ResidenceAggregate, ...]:
     """内側 Session FileDB から AreaManager 単位の住居サマリを抽出．
 
     プレイヤー島だけじゃなく Residence7 を持つ全 AreaManager を返す (NPC 都市
     含む)．プレイヤー絞り込みは上位 layer の city name 結合で行う．
+
+    ``buildings`` を渡すと親 ``objects > <1>`` の ``guid`` attrib から
+    ``BuildingEntry.tier`` を引き，``tier_breakdown`` に tier 別集計を populate
+    する．未指定なら ``tier_breakdown`` は空 tuple になり既存挙動と一致．
     """
     if not inner_session:
         return ()
     version = detect_version(inner_session)
     section = parse_tag_section(inner_session, version)
-    accums = _walk_residences(inner_session, version, section)
+    accums = _walk_residences(inner_session, version, section, buildings)
     return tuple(_freeze(acc) for acc in accums.values() if acc.residence_count > 0)
 
 
 def _walk_residences(
-    inner: bytes, version, section: TagSection
+    inner: bytes,
+    version,
+    section: TagSection,
+    buildings: BuildingDictionary | None,
 ) -> dict[str, _ResidenceAccumMutable]:
     id2name = dict(section.tags.entries)
     r7_id = next((i for i, n in id2name.items() if n == _RESIDENCE7), None)
@@ -148,6 +186,8 @@ def _walk_residences(
     stack: list[str] = []
     accums: dict[str, _ResidenceAccumMutable] = {}
     in_am: tuple[int, str] | None = None
+    in_obj_entry: int | None = None  # objects > <1> の depth
+    obj_guid: int | None = None  # 現在の object entry の ``guid`` attrib
     in_r7: int | None = None
     current_residence: dict[str, bytes] = {}
     in_cs: int | None = None
@@ -168,6 +208,15 @@ def _walk_residences(
             if name.startswith(_AREA_MANAGER_PREFIX) and in_am is None:
                 in_am = (depth, name)
                 accums.setdefault(name, _ResidenceAccumMutable(area_manager=name))
+            elif (
+                in_am is not None
+                and in_obj_entry is None
+                and name == "<1>"
+                and len(stack) >= 2
+                and stack[-2] == _OBJECTS
+            ):
+                in_obj_entry = depth
+                obj_guid = None
             elif in_am is not None and ev.id_ == r7_id and in_r7 is None:
                 in_r7 = depth
                 current_residence = {}
@@ -180,7 +229,14 @@ def _walk_residences(
             continue
 
         if ev.kind is EventKind.ATTRIB:
-            if in_r7 is not None and len(stack) == in_r7:
+            if (
+                in_obj_entry is not None
+                and in_r7 is None
+                and len(stack) == in_obj_entry
+                and ev.name == _GUID_ATTRIB
+            ):
+                obj_guid = _i32(ev.content)
+            elif in_r7 is not None and len(stack) == in_r7:
                 current_residence[ev.name or ""] = ev.content
             elif (
                 in_cs is not None
@@ -228,13 +284,34 @@ def _walk_residences(
                 acc.product_money_total += prod_money
                 acc.newspaper_money_total += newsp_money
                 acc.saturation_weighted += avg_sat * residents
+                # tier 分類．buildings が与えられている場合のみ意味がある．
+                if buildings is not None:
+                    tier_key = _resolve_tier(obj_guid, buildings)
+                    bucket = acc.tier_totals.setdefault(tier_key, [0, 0, 0.0])
+                    bucket[0] += 1  # residence_count
+                    bucket[1] += residents
+                    bucket[2] += avg_sat * residents
             in_r7 = None
             current_residence = {}
+        if in_obj_entry is not None and closing_depth == in_obj_entry:
+            in_obj_entry = None
+            obj_guid = None
         if in_am is not None and closing_depth == in_am[0]:
             in_am = None
         stack.pop()
 
     return accums
+
+
+def _resolve_tier(guid: int | None, buildings: BuildingDictionary) -> str:
+    """``BuildingDictionary`` で building_guid → tier 文字列を引く．判定不能は
+    ``"unknown"`` を返す．"""
+    if guid is None:
+        return _UNKNOWN_TIER
+    entry = buildings.get(guid)
+    if entry is None or entry.tier is None:
+        return _UNKNOWN_TIER
+    return entry.tier
 
 
 class _ResidenceAccumMutable:
@@ -246,6 +323,7 @@ class _ResidenceAccumMutable:
         "newspaper_money_total",
         "saturation_weighted",
         "product_saturation_totals",
+        "tier_totals",
     )
 
     def __init__(self, area_manager: str) -> None:
@@ -256,6 +334,9 @@ class _ResidenceAccumMutable:
         self.newspaper_money_total = 0
         self.saturation_weighted = 0.0
         self.product_saturation_totals: dict[int, list[float]] = {}
+        # key: tier name (``"farmer"`` / ``"unknown"`` 等)，
+        # value: [residence_count, resident_total, saturation_weighted]
+        self.tier_totals: dict[str, list] = {}
 
 
 def _freeze(acc: _ResidenceAccumMutable) -> ResidenceAggregate:
@@ -265,6 +346,18 @@ def _freeze(acc: _ResidenceAccumMutable) -> ResidenceAggregate:
             continue
         sats.append(ProductSaturation(product_guid=guid, current=sum_cur / n, average=sum_avg / n))
     mean_sat = acc.saturation_weighted / acc.resident_total if acc.resident_total else 0.0
+    tier_breakdown: list[TierSummary] = []
+    for tier_key in sorted(acc.tier_totals.keys()):
+        count, residents, sat_weighted = acc.tier_totals[tier_key]
+        tier_mean = sat_weighted / residents if residents else 0.0
+        tier_breakdown.append(
+            TierSummary(
+                tier=tier_key,
+                residence_count=count,
+                resident_total=residents,
+                avg_saturation_mean=tier_mean,
+            )
+        )
     return ResidenceAggregate(
         area_manager=acc.area_manager,
         residence_count=acc.residence_count,
@@ -273,6 +366,7 @@ def _freeze(acc: _ResidenceAccumMutable) -> ResidenceAggregate:
         newspaper_money_total=acc.newspaper_money_total,
         avg_saturation_mean=mean_sat,
         product_saturations=tuple(sats),
+        tier_breakdown=tuple(tier_breakdown),
     )
 
 

--- a/tests/trade/test_anno1800_tier_breakdown_smoke.py
+++ b/tests/trade/test_anno1800_tier_breakdown_smoke.py
@@ -1,0 +1,78 @@
+"""Anno 1800 実セーブでの Residence tier breakdown smoke test．
+
+書記長の ``sample_anno1800.a7s`` + packaged ``buildings_anno1800.en.yaml``
+を使って ``list_residence_aggregates(buildings=...)`` が実データで意味ある
+tier 分解を返すことを確認する．
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from anno_save_analyzer.parser.filedb import detect_version, parse_tag_section
+from anno_save_analyzer.parser.filedb.session import extract_sessions
+from anno_save_analyzer.parser.pipeline import extract_inner_filedb
+from anno_save_analyzer.trade.buildings import BuildingDictionary
+from anno_save_analyzer.trade.population import list_residence_aggregates
+
+SAMPLE_PATH = Path(__file__).resolve().parents[2] / "sample_anno1800.a7s"
+_HAS_SAMPLE = SAMPLE_PATH.is_file()
+
+
+@pytest.mark.skipif(not _HAS_SAMPLE, reason=f"Anno 1800 sample not found: {SAMPLE_PATH}")
+class TestAnno1800TierBreakdownSmoke:
+    @pytest.fixture(scope="class")
+    def aggregates(self) -> list:
+        """packaged buildings を使って全 session の ResidenceAggregate を集める．"""
+        buildings = BuildingDictionary.load()
+        outer = extract_inner_filedb(SAMPLE_PATH)
+        ver = detect_version(outer)
+        sec = parse_tag_section(outer, ver)
+        out = []
+        for inner in extract_sessions(outer, ver, sec):
+            out.extend(list_residence_aggregates(inner, buildings=buildings))
+        return out
+
+    def test_aggregates_populated(self, aggregates: list) -> None:
+        """書記長 save は 17+ 島 (Arctic 除く) で residence がある．"""
+        populated = [a for a in aggregates if a.residence_count > 0]
+        assert len(populated) >= 10
+
+    def test_tier_breakdown_populated_when_buildings_given(self, aggregates: list) -> None:
+        """buildings を与えると tier_breakdown が空でなくなる．"""
+        with_breakdown = [a for a in aggregates if a.tier_breakdown]
+        assert len(with_breakdown) >= 10
+
+    def test_known_tier_appears_in_breakdown(self, aggregates: list) -> None:
+        """主要 tier (farmer / worker / artisan / engineer / investor) の少なくとも
+        どれかが実 save で抽出される．tier 判定ロジックが死んでないかのガード．"""
+        all_tiers: set[str] = set()
+        for agg in aggregates:
+            for ts in agg.tier_breakdown:
+                all_tiers.add(ts.tier)
+        known = {"farmer", "worker", "artisan", "engineer", "investor"}
+        assert all_tiers & known, f"no known tier found: {sorted(all_tiers)}"
+
+    def test_tier_resident_totals_sum_to_aggregate(self, aggregates: list) -> None:
+        """tier_breakdown の ``resident_total`` 合計は島全体の ``resident_total``
+        と一致する．invariant がずれたら集計バグ．"""
+        for agg in aggregates:
+            if not agg.tier_breakdown:
+                continue
+            tier_sum = sum(ts.resident_total for ts in agg.tier_breakdown)
+            assert tier_sum == agg.resident_total, (
+                f"tier sum {tier_sum} != island total {agg.resident_total} for {agg.area_manager}"
+            )
+
+    def test_tier_residence_counts_sum_to_aggregate(self, aggregates: list) -> None:
+        """residence_count も同様に invariant．"""
+        for agg in aggregates:
+            if not agg.tier_breakdown:
+                continue
+            tier_sum = sum(ts.residence_count for ts in agg.tier_breakdown)
+            assert tier_sum == agg.residence_count, (
+                f"tier residence sum {tier_sum} != island total {agg.residence_count} "
+                f"for {agg.area_manager}"
+            )

--- a/tests/trade/test_population.py
+++ b/tests/trade/test_population.py
@@ -10,6 +10,7 @@ import struct
 
 import pytest
 
+from anno_save_analyzer.trade.buildings import BuildingDictionary, BuildingEntry
 from anno_save_analyzer.trade.population import (
     CityAreaMatch,
     ResidenceAggregate,
@@ -243,3 +244,160 @@ class TestCityAreaMatch:
         assert m.city_name == "Osaka"
         assert m.area_manager == "AreaManager_8771"
         assert m.jaccard == 0.42
+
+
+# ---------------- Tier breakdown ----------------
+
+
+def _build_am_with_object_residences(
+    am_tag_name: str = "AreaManager_8771",
+    residences: list[dict] | None = None,
+) -> bytes:
+    """``AreaManager > GameObject > objects > <1>`` 階層を挟んで Residence7 を配置．
+
+    各 residence dict は ``_build_am_with_residences`` と同仕様に加えて
+    ``guid`` キーを持つ．object entry 直下の ``guid`` attrib として書き出し，
+    ``BuildingDictionary`` の tier ルックアップ対象になる．
+    """
+    residences = residences or []
+    tags = {
+        2: am_tag_name,
+        3: "GameObject",
+        4: "objects",
+        5: "Residence7",
+        6: "ConsumptionStates",
+    }
+    attribs = {
+        0x8001: "ResidentCount",
+        0x8002: "ProductMoneyOutput",
+        0x8003: "NewspaperMoneyOutput",
+        0x8004: "AverageNeedSaturation",
+        0x8005: "CurrentSaturation",
+        0x8006: "AverageSaturation",
+        0x8007: "guid",
+    }
+    events: list[Event] = [("T", 2), ("T", 3), ("T", 4)]  # AreaManager > GameObject > objects
+    for r in residences:
+        events.append(("T", 1))  # <1> object entry
+        if r.get("guid") is not None:
+            events.append(("A", 0x8007, _i32_bytes(r["guid"])))
+        events.append(("T", 5))  # Residence7
+        events.append(("A", 0x8001, _i32_bytes(r.get("resident_count", 0))))
+        events.append(("A", 0x8004, _f32_bytes(r.get("avg_saturation", 0.0))))
+        events.append(("X",))  # close Residence7
+        events.append(("X",))  # close <1>
+    events.append(("X",))  # close objects
+    events.append(("X",))  # close GameObject
+    events.append(("X",))  # close AreaManager
+    return minimal_v3(tags=tags, attribs=attribs, events=events)
+
+
+def _dict(entries: dict[int, BuildingEntry]) -> BuildingDictionary:
+    return BuildingDictionary(entries=entries)
+
+
+class TestTierBreakdown:
+    def test_no_buildings_yields_empty_tier_breakdown(self) -> None:
+        """buildings 未指定 (既存呼び出し互換) なら tier_breakdown は空．"""
+        buf = _build_am_with_object_residences(
+            residences=[{"guid": 1010343, "resident_count": 10, "avg_saturation": 0.5}]
+        )
+        out = list_residence_aggregates(buf)
+        assert len(out) == 1
+        assert out[0].tier_breakdown == ()
+        assert out[0].resident_total == 10
+
+    def test_single_tier_all_residences(self) -> None:
+        """全住居が同じ tier．tier_breakdown に 1 件 summary が出る．"""
+        buildings = _dict(
+            {
+                1010343: BuildingEntry(
+                    guid=1010343,
+                    name="Farmer Residence",
+                    kind="residence",
+                    template="ResidenceBuilding",
+                    tier="farmer",
+                )
+            }
+        )
+        buf = _build_am_with_object_residences(
+            residences=[
+                {"guid": 1010343, "resident_count": 10, "avg_saturation": 0.5},
+                {"guid": 1010343, "resident_count": 20, "avg_saturation": 0.8},
+            ]
+        )
+        out = list_residence_aggregates(buf, buildings=buildings)
+        agg = out[0]
+        assert agg.resident_total == 30
+        assert len(agg.tier_breakdown) == 1
+        ts = agg.tier_breakdown[0]
+        assert ts.tier == "farmer"
+        assert ts.residence_count == 2
+        assert ts.resident_total == 30
+        # residents weighted mean: (10*0.5 + 20*0.8) / 30 = 0.7
+        assert ts.avg_saturation_mean == pytest.approx(0.7)
+
+    def test_mixed_tiers_separated(self) -> None:
+        """複数 tier が混在する場合にそれぞれ集計される．"""
+        buildings = _dict(
+            {
+                1010343: BuildingEntry(
+                    guid=1010343,
+                    name="Farmer",
+                    kind="residence",
+                    template="ResidenceBuilding",
+                    tier="farmer",
+                ),
+                1010345: BuildingEntry(
+                    guid=1010345,
+                    name="Worker",
+                    kind="residence",
+                    template="ResidenceBuilding",
+                    tier="worker",
+                ),
+            }
+        )
+        buf = _build_am_with_object_residences(
+            residences=[
+                {"guid": 1010343, "resident_count": 10, "avg_saturation": 0.9},
+                {"guid": 1010345, "resident_count": 50, "avg_saturation": 0.6},
+                {"guid": 1010345, "resident_count": 30, "avg_saturation": 0.4},
+            ]
+        )
+        out = list_residence_aggregates(buf, buildings=buildings)
+        breakdown = {ts.tier: ts for ts in out[0].tier_breakdown}
+        assert set(breakdown) == {"farmer", "worker"}
+        assert breakdown["farmer"].residence_count == 1
+        assert breakdown["farmer"].resident_total == 10
+        assert breakdown["worker"].residence_count == 2
+        assert breakdown["worker"].resident_total == 80
+        # worker weighted mean: (50*0.6 + 30*0.4) / 80 = 0.525
+        assert breakdown["worker"].avg_saturation_mean == pytest.approx(0.525)
+
+    def test_unknown_tier_fallback_when_guid_missing_or_no_tier(self) -> None:
+        """buildings に登録されてない / tier=None な住居は ``unknown`` に集約．"""
+        buildings = _dict(
+            {
+                # tier 無し
+                1010343: BuildingEntry(
+                    guid=1010343,
+                    name="Colony",
+                    kind="residence",
+                    template="ResidenceBuilding7_Colony",
+                    tier=None,
+                ),
+            }
+        )
+        buf = _build_am_with_object_residences(
+            residences=[
+                {"guid": 1010343, "resident_count": 10, "avg_saturation": 0.5},
+                # buildings に未登録な guid
+                {"guid": 9999999, "resident_count": 5, "avg_saturation": 0.3},
+            ]
+        )
+        out = list_residence_aggregates(buf, buildings=buildings)
+        breakdown = {ts.tier: ts for ts in out[0].tier_breakdown}
+        assert breakdown == {"unknown": breakdown["unknown"]}
+        # 両住居まとめて unknown に合流
+        assert breakdown["unknown"].residence_count == 2
+        assert breakdown["unknown"].resident_total == 15


### PR DESCRIPTION
## Summary

v0.4 supply-balance milestone (#64)．``trade/population.py`` の
``ResidenceAggregate`` に **tier 別** (Farmer / Worker / Artisan / Engineer /
Investor / ...) の集計を追加する．#12 Balance engine で「tier 人口 × tpmin =
消費量」を算出するための前提．

## API

```python
from anno_save_analyzer.trade.buildings import BuildingDictionary
from anno_save_analyzer.trade.population import list_residence_aggregates

buildings = BuildingDictionary.load()  # packaged YAML
aggs = list_residence_aggregates(inner_session_bytes, buildings=buildings)
for agg in aggs:
    print(agg.area_manager, agg.resident_total)
    for ts in agg.tier_breakdown:
        print(f"  {ts.tier}: {ts.resident_total} residents ({ts.residence_count} houses)")
```

## 実装詳細

- 既存 ``list_residence_aggregates`` のシグネチャに ``buildings`` optional 引数
  を追加．未指定なら ``tier_breakdown = ()`` で既存互換
- state machine に ``objects > <1>`` 階層と ``guid`` attrib 追跡を追加 (#66
  Factory7 extractor と同パターン)
- ``BuildingDictionary`` で tier 判定不能な residence (Arctic / Colony 系で
  ``residence_tier0N`` 命名外) は ``"unknown"`` に集約

## Invariant

tier_breakdown の residents / residence_count 合計 = 島全体の
resident_total / residence_count．smoke test でアサート．

## Test plan

- [x] 合成 FileDB unit 4 件 (buildings 無 / 単一 tier / 複数 tier mix /
      unknown fallback)
- [x] 実 save smoke 5 件 (populated / tier 取得 / known tier 存在 /
      invariant 2 つ)
- [x] 既存 test_population.py 15 件は破壊せず通過
- [x] pytest 全体 585 passed / coverage 維持
- [x] ruff check + format clean

Refs: #64