### PR TITLE
feat(cli): anno-save-analyzer state — JSON dump for pandas/jupyter

### DIFF
--- a/src/anno_save_analyzer/cli/__main__.py
+++ b/src/anno_save_analyzer/cli/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 
+from .state import register as register_state
 from .trade import trade_app
 from .tui import register as register_tui
 
@@ -14,6 +15,7 @@ app = typer.Typer(
 )
 app.add_typer(trade_app, name="trade")
 register_tui(app)
+register_state(app)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/anno_save_analyzer/cli/state.py
+++ b/src/anno_save_analyzer/cli/state.py
@@ -1,0 +1,185 @@
+"""``anno-save-analyzer state`` — save の全抽出結果を JSON に吐く．
+
+書記長が pandas / jupyter で分析を回すための 1 本の canonical なダンプ．
+内容は Overview + 島ごとの (tier_breakdown / factories / supply balance) +
+全 TradeEvent．
+
+Usage::
+
+    anno-save-analyzer state sample_anno1800.a7s --title anno1800 --out state.json
+
+出力は整形済 UTF-8 (日本語 raw)．
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from anno_save_analyzer.trade.balance import IslandBalance, ProductBalance
+from anno_save_analyzer.trade.models import GameTitle, TradeEvent
+from anno_save_analyzer.trade.population import ResidenceAggregate, TierSummary
+from anno_save_analyzer.tui.i18n import Localizer
+from anno_save_analyzer.tui.state import TuiState, load_state
+
+
+def dump_state(  # noqa: PLR0913,B008 — CLI entrypoint．typer.Argument/Option は default で使う慣例
+    save: Path = typer.Argument(..., help="Anno save file (.a7s / .a8s)", exists=True),  # noqa: B008
+    title: str = typer.Option(  # noqa: B008
+        GameTitle.ANNO_1800.value,
+        "--title",
+        help="Game title: anno1800 / anno117",
+    ),
+    locale: str = typer.Option(  # noqa: B008
+        "en", "--locale", help="UI locale used to resolve display names"
+    ),
+    out: Path = typer.Option(..., "--out", "-o", help="Output JSON file path"),  # noqa: B008
+    include_events: bool = typer.Option(  # noqa: B008
+        True,
+        "--events/--no-events",
+        help="Include full TradeEvent ledger (can be large)",
+    ),
+    indent: int = typer.Option(2, "--indent", help="JSON indent (0 = compact)"),  # noqa: B008
+) -> None:
+    """Load the save and dump a single JSON document to ``--out``．"""
+    title_enum = GameTitle(title)
+    state = load_state(save, title=title_enum, locale=locale)
+    localizer = Localizer.load(locale)
+    payload = _build_payload(state, localizer, include_events=include_events)
+    text = json.dumps(payload, ensure_ascii=False, indent=indent if indent > 0 else None)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    print(f"wrote {out} ({len(text):,} bytes)", file=sys.stderr)
+
+
+def _build_payload(
+    state: TuiState, localizer: Localizer, *, include_events: bool
+) -> dict[str, Any]:
+    """``TuiState`` から JSON-safe な dict に整形する．
+
+    Pydantic の ``model_dump(mode="json")`` を base に使いつつ，
+    区切りがわかりやすいよう事前に島単位のマージ (balance + factories +
+    tier_breakdown + session + city) を行う．
+    """
+    return {
+        "save": str(state.save_path),
+        "title": state.title.value,
+        "locale": state.locale,
+        "overview": _overview_dict(state),
+        "islands": _islands_list(state, localizer),
+        "trade_events": (
+            [_event_dict(ev, state) for ev in state.events] if include_events else None
+        ),
+    }
+
+
+def _overview_dict(state: TuiState) -> dict[str, Any]:
+    snap = state.overview
+    return {
+        "save_path": str(snap.save_path),
+        "title": snap.title.value,
+        "session_ids": list(snap.session_ids),
+        "total_events": snap.total_events,
+        "distinct_goods": snap.distinct_goods,
+        "distinct_routes": snap.distinct_routes,
+        "net_gold": snap.net_gold,
+    }
+
+
+def _islands_list(state: TuiState, localizer: Localizer) -> list[dict[str, Any]]:
+    """island 単位の集計 (residence + factory + balance) をマージした行のリスト．"""
+    balance = state.balance_table
+    residences: dict[str, ResidenceAggregate] = {}
+    for agg in state.population_by_city.values():
+        residences.setdefault(agg.area_manager, agg)
+
+    # tui state は factory aggregates を露出してないため balance からのみ情報を
+    # 取る (balance_table が None なら island list も空)．
+    out: list[dict[str, Any]] = []
+    if balance is None:
+        return out
+    for isl in balance.islands:
+        city_name = state.area_manager_to_city.get(isl.area_manager) or isl.city_name
+        session_key = state.area_manager_to_session_key.get(isl.area_manager)
+        session_display = localizer.t(session_key) if session_key else None
+        residence_agg = residences.get(isl.area_manager)
+        tier_breakdown = (
+            [_tier_dict(ts) for ts in residence_agg.tier_breakdown] if residence_agg else []
+        )
+        out.append(
+            {
+                "area_manager": isl.area_manager,
+                "city_name": city_name,
+                "is_player": city_name is not None,
+                "session_key": session_key,
+                "session_display": session_display,
+                "resident_total": isl.resident_total,
+                "residence_count": residence_agg.residence_count if residence_agg else 0,
+                "avg_saturation": residence_agg.avg_saturation_mean if residence_agg else None,
+                "tier_breakdown": tier_breakdown,
+                "balance": _island_balance_dict(isl, state),
+            }
+        )
+    return out
+
+
+def _tier_dict(ts: TierSummary) -> dict[str, Any]:
+    return {
+        "tier": ts.tier,
+        "residence_count": ts.residence_count,
+        "resident_total": ts.resident_total,
+        "avg_saturation_mean": ts.avg_saturation_mean,
+    }
+
+
+def _island_balance_dict(isl: IslandBalance, state: TuiState) -> dict[str, Any]:
+    return {
+        "products": [_product_balance_dict(p, state) for p in isl.products],
+        "deficit_count": sum(1 for p in isl.products if p.is_deficit),
+    }
+
+
+def _product_balance_dict(p: ProductBalance, state: TuiState) -> dict[str, Any]:
+    item = state.items[p.product_guid]
+    return {
+        "product_guid": p.product_guid,
+        "name": item.display_name(state.locale) or f"Good_{p.product_guid}",
+        "name_en": item.names.get("en"),
+        "produced_per_minute": p.produced_per_minute,
+        "consumed_per_minute": p.consumed_per_minute,
+        "delta_per_minute": p.delta_per_minute,
+        "is_deficit": p.is_deficit,
+    }
+
+
+def _event_dict(ev: TradeEvent, state: TuiState) -> dict[str, Any]:
+    """TradeEvent を JSON-safe な dict に．Pydantic ``model_dump`` でも行けるが
+    item を product_guid だけでなく name も添えて分析しやすくする．
+    """
+    item_name = ev.item.display_name(state.locale) or f"Good_{ev.item.guid}"
+    return {
+        "timestamp_tick": ev.timestamp_tick,
+        "product_guid": ev.item.guid,
+        "product_name": item_name,
+        "amount": ev.amount,
+        "total_price": ev.total_price,
+        "session_id": ev.session_id,
+        "island_name": ev.island_name,
+        "route_id": ev.route_id,
+        "route_name": ev.route_name,
+        "partner_id": ev.partner.id if ev.partner else None,
+        "partner_kind": ev.partner.kind if ev.partner else None,
+        "source_method": ev.source_method,
+    }
+
+
+def register(app: typer.Typer) -> None:
+    """Register ``state`` subcommand onto the root typer app."""
+    app.command(
+        name="state",
+        help="Dump the full analysis state as JSON (for pandas / jupyter).",
+    )(dump_state)

--- a/tests/cli/test_state.py
+++ b/tests/cli/test_state.py
@@ -1,0 +1,138 @@
+"""``anno-save-analyzer state`` の JSON export テスト．
+
+合成 save で pipeline を通し，JSON の構造が期待通りかを確認する．
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from anno_save_analyzer.cli.__main__ import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def synthetic_save(tmp_path: Path) -> Path:
+    """TUI test fixtures と同じ合成 inner FileDB で保存 file を作る．"""
+    from tests.trade.conftest import make_inner_filedb, wrap_as_outer
+
+    inner_a = make_inner_filedb({"route": [(7, 100, 5, 0), (7, 200, -3, 0)]})
+    inner_b = make_inner_filedb({"route": [(8, 200, 2, 0)]})
+    outer = wrap_as_outer([inner_a, inner_b])
+    save = tmp_path / "fake.bin"
+    save.write_bytes(outer)
+    return save
+
+
+@pytest.fixture
+def synth_items_dir(tmp_path: Path) -> Path:
+    """117 タイトル向けの最小 items YAML を data dir に用意．"""
+    (tmp_path / "items_anno117.en.yaml").write_text(
+        "100:\n  name: Wood\n  category: raw\n200:\n  name: Bricks\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "items_anno117.ja.yaml").write_text(
+        "100:\n  name: 木材\n200:\n  name: 煉瓦\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_state_command_writes_expected_toplevel_keys(
+    runner: CliRunner, synthetic_save: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """117 合成 save で state コマンドが JSON を書き，既知 top-level キーが揃う．"""
+    out = tmp_path / "state.json"
+    # items YAML は packaged を使わせる (117 packaged は repo に存在するのでそのまま)
+    result = runner.invoke(
+        app,
+        [
+            "state",
+            str(synthetic_save),
+            "--title",
+            "anno117",
+            "--locale",
+            "en",
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert set(data) >= {"save", "title", "locale", "overview", "islands", "trade_events"}
+    assert data["title"] == "anno117"
+    assert data["locale"] == "en"
+    assert isinstance(data["trade_events"], list)
+
+
+def test_state_command_no_events_flag_drops_ledger(
+    runner: CliRunner, synthetic_save: Path, tmp_path: Path
+) -> None:
+    """``--no-events`` で ``trade_events`` が ``null`` になる．"""
+    out = tmp_path / "state.json"
+    result = runner.invoke(
+        app,
+        [
+            "state",
+            str(synthetic_save),
+            "--title",
+            "anno117",
+            "--no-events",
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["trade_events"] is None
+
+
+def test_state_command_compact_indent(
+    runner: CliRunner, synthetic_save: Path, tmp_path: Path
+) -> None:
+    """``--indent 0`` で compact JSON．改行なしであることを確認．"""
+    out = tmp_path / "state.json"
+    result = runner.invoke(
+        app,
+        [
+            "state",
+            str(synthetic_save),
+            "--title",
+            "anno117",
+            "--indent",
+            "0",
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    text = out.read_text(encoding="utf-8")
+    # indent=0 なら改行文字数が 1 行分のみ (end newline は json.dumps で付かない)
+    assert "\n" not in text
+
+
+def test_state_command_missing_save_fails(runner: CliRunner, tmp_path: Path) -> None:
+    """存在しない save path は click の ``exists=True`` で落ちる．"""
+    out = tmp_path / "state.json"
+    result = runner.invoke(
+        app,
+        [
+            "state",
+            str(tmp_path / "does_not_exist.a7s"),
+            "--title",
+            "anno117",
+            "--out",
+            str(out),
+        ],
+    )
+    assert result.exit_code != 0
+    assert not out.exists()


### PR DESCRIPTION
## Summary

書記長要望: 「どういうデータが取れてるか JSON ほしい．分析回したい」

CLI サブコマンド ``state`` を新設．Overview / 島ごとの balance + tier
breakdown / 全 TradeEvent を 1 つの JSON に dump する．pandas / jupyter
で直接読める形．

## Usage

```bash
anno-save-analyzer state sample_anno1800.a7s \\
    --title anno1800 --locale ja \\
    --out state.json [--no-events] [--indent 0]
```

実測: sample_anno1800.a7s + ``--events`` で **~970 KB / 36,697 行**．

## 分析例

```python
import json, pandas as pd
data = json.load(open("state.json"))

islands = pd.json_normalize(data["islands"])
# island 毎の赤字物資数 ランキング
islands.sort_values("balance.deficit_count", ascending=False)

# tier 別の人口集計
tier_df = pd.json_normalize(
    data["islands"], "tier_breakdown", ["city_name", "session_display"]
)
tier_df.groupby(["tier", "session_display"])["resident_total"].sum()

events = pd.json_normalize(data["trade_events"])
# 物資別 純収支
events.groupby("product_name")["total_price"].sum().sort_values()
```

## 出力構造

- ``save`` / ``title`` / ``locale``
- ``overview``: ``total_events`` / ``distinct_goods`` / ``net_gold`` など
- ``islands[]``:
  - ``area_manager`` / ``city_name`` / ``is_player``
  - ``session_key`` (``session.anno1800.cape_trelawney``) / ``session_display``
    (localizer 解決後)
  - ``resident_total`` / ``residence_count`` / ``avg_saturation``
  - ``tier_breakdown[]``: ``{tier, residents, residence_count, saturation}``
  - ``balance``: ``{products: [{guid, name, name_en, produced, consumed, delta, is_deficit}], deficit_count}``
- ``trade_events[]`` (``--no-events`` で ``null``): timestamp / product /
  amount / total_price / island_name / route_id / partner_kind など

## Test plan

- [x] ``tests/cli/test_state.py`` 4 件 (top-level keys / ``--no-events`` /
      ``--indent 0`` / missing save)
- [x] 全体 pytest 623 passed / coverage 維持
- [x] ruff check + format clean
- [x] 手動 ``anno-save-analyzer state sample_anno1800.a7s`` で実 JSON 出力確認

## 依存

- ``dev`` 起点．#79 は merge 待ちだが本 PR のみでも動く (``balance_table``
  / ``area_manager_to_*`` は ``dev`` に取り込み済)．
- session 順の swap (#79 fix 3/3) は本 PR の scope 外．merge 後に dev
  から順序が整う．

Refs: (書記長依頼)