### PR TITLE
feat(analysis): TuiState → pandas DataFrame 変換層 (#81)

### DIFF
--- a/src/anno_save_analyzer/analysis/__init__.py
+++ b/src/anno_save_analyzer/analysis/__init__.py
@@ -1,0 +1,16 @@
+"""SCM analytics: ``TuiState`` を pandas DataFrame に変換する分析層．
+
+v0.5 milestone の前提 (#81-A)．``to_frames`` で 4 本の DataFrame
+(islands / tiers / balance / trade_events) を得てから，deficit heatmap /
+相関 / route ランキング / 予測 / MILP 等の後続 analyzer を chain する．
+
+Title 非依存: Anno 117 / Anno 1800 の両方で動く．``consumption`` /
+``factory_recipes`` が無い title では balance は空 DataFrame だが schema
+は維持する．
+"""
+
+from __future__ import annotations
+
+from .frames import AnalysisFrames, to_frames
+
+__all__ = ["AnalysisFrames", "to_frames"]

--- a/src/anno_save_analyzer/analysis/frames.py
+++ b/src/anno_save_analyzer/analysis/frames.py
@@ -1,0 +1,267 @@
+"""``TuiState`` を pandas DataFrame に変換する中核ユーティリティ．
+
+4 本の正規化された DataFrame を持つ ``AnalysisFrames`` を出力する．
+後続の analyzer (deficit map / correlation / route ranking / forecast /
+MILP) は全てこの DataFrame 表現を入力に取る．
+
+## DataFrames
+
+### ``islands``
+1 row = 1 island (AreaManager)．
+
+| column | 型 | 説明 |
+|---|---|---|
+| ``area_manager`` | str | ``AreaManager_<N>`` タグ名 (join キー) |
+| ``city_name`` | str/None | プレイヤー島なら設定．NPC は None |
+| ``is_player`` | bool | ``city_name`` の有無で判定 |
+| ``session_key`` | str/None | ``session.anno1800.cape_trelawney`` など |
+| ``session_display`` | str/None | Localizer 解決後 (「トレローニー岬」) |
+| ``resident_total`` | int | 島の全人口 |
+| ``residence_count`` | int | 住居総数 |
+| ``avg_saturation_mean`` | float | 平均需要満足度 (residents-weighted) |
+| ``deficit_count`` | int | balance table で赤字の物資数 |
+
+### ``tiers``
+1 row = 1 (island, tier)．
+
+| column | 型 | 説明 |
+|---|---|---|
+| ``area_manager`` | str | join キー |
+| ``city_name`` | str/None | |
+| ``tier`` | str | ``farmer`` / ``worker`` / ... / ``unknown`` |
+| ``residence_count`` | int | |
+| ``resident_total`` | int | |
+| ``avg_saturation_mean`` | float | tier 単位の saturation |
+
+### ``balance``
+1 row = 1 (island, product)．島の供給消費バランス．
+
+| column | 型 | 説明 |
+|---|---|---|
+| ``area_manager`` | str | |
+| ``city_name`` | str/None | |
+| ``product_guid`` | int | |
+| ``product_name`` | str | locale 適用後 |
+| ``produced_per_minute`` | float | |
+| ``consumed_per_minute`` | float | |
+| ``delta_per_minute`` | float | 負=赤字 |
+| ``is_deficit`` | bool | |
+
+### ``trade_events``
+1 row = 1 TradeEvent．時系列分析の入力．
+
+| column | 型 | 説明 |
+|---|---|---|
+| ``timestamp_tick`` | Int64 | nullable integer．分単位変換は後続 |
+| ``product_guid`` | int | |
+| ``product_name`` | str | |
+| ``amount`` | int | |
+| ``total_price`` | int | |
+| ``session_id`` | str/None | |
+| ``island_name`` | str/None | |
+| ``route_id`` | str/None | ``str`` 化して ``route:123`` 形式で統一 |
+| ``route_name`` | str/None | |
+| ``partner_id`` | str/None | |
+| ``partner_kind`` | str/None | ``route`` / ``passive`` / ``unknown`` |
+| ``source_method`` | str | ``history`` 等 |
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from anno_save_analyzer.tui.i18n import Localizer
+from anno_save_analyzer.tui.state import TuiState
+
+_ISLANDS_COLUMNS = (
+    "area_manager",
+    "city_name",
+    "is_player",
+    "session_key",
+    "session_display",
+    "resident_total",
+    "residence_count",
+    "avg_saturation_mean",
+    "deficit_count",
+)
+_TIERS_COLUMNS = (
+    "area_manager",
+    "city_name",
+    "tier",
+    "residence_count",
+    "resident_total",
+    "avg_saturation_mean",
+)
+_BALANCE_COLUMNS = (
+    "area_manager",
+    "city_name",
+    "product_guid",
+    "product_name",
+    "produced_per_minute",
+    "consumed_per_minute",
+    "delta_per_minute",
+    "is_deficit",
+)
+_TRADE_EVENT_COLUMNS = (
+    "timestamp_tick",
+    "product_guid",
+    "product_name",
+    "amount",
+    "total_price",
+    "session_id",
+    "island_name",
+    "route_id",
+    "route_name",
+    "partner_id",
+    "partner_kind",
+    "source_method",
+)
+
+
+@dataclass(frozen=True)
+class AnalysisFrames:
+    """分析層 4 本の DataFrame を保持．
+
+    pandas DataFrame 自体は mutable なので dataclass の frozen は **参照
+    差し替え禁止** 程度の保護 (中の値は書換可能)．分析 pipeline は純関数
+    で書くこと．
+    """
+
+    islands: pd.DataFrame
+    tiers: pd.DataFrame
+    balance: pd.DataFrame
+    trade_events: pd.DataFrame
+
+
+def to_frames(state: TuiState, *, localizer: Localizer | None = None) -> AnalysisFrames:
+    """``TuiState`` を ``AnalysisFrames`` に変換する．
+
+    ``localizer`` 省略時は ``state.locale`` に対応する Localizer を load．
+    後続の analyzer は pandas の ``groupby`` / ``pivot`` / ``merge`` で
+    記述できる．
+    """
+    loc = localizer or Localizer.load(state.locale)
+    islands_df = _islands_df(state, loc)
+    tiers_df = _tiers_df(state, islands_df)
+    balance_df = _balance_df(state, islands_df)
+    events_df = _trade_events_df(state)
+    return AnalysisFrames(
+        islands=islands_df,
+        tiers=tiers_df,
+        balance=balance_df,
+        trade_events=events_df,
+    )
+
+
+def _islands_df(state: TuiState, localizer: Localizer) -> pd.DataFrame:
+    balance = state.balance_table
+    # AreaManager → ResidenceAggregate lookup (city_name 無い島も拾いたいので
+    # population_by_city よりも直接抽出の方が漏れないが現 state 経由が簡単)
+    residences_by_am = {agg.area_manager: agg for agg in state.population_by_city.values()}
+
+    rows: list[dict] = []
+    if balance is not None:
+        for isl in balance.islands:
+            city_name = state.area_manager_to_city.get(isl.area_manager) or isl.city_name
+            session_key = state.area_manager_to_session_key.get(isl.area_manager)
+            session_display = localizer.t(session_key) if session_key else None
+            residence = residences_by_am.get(isl.area_manager)
+            rows.append(
+                {
+                    "area_manager": isl.area_manager,
+                    "city_name": city_name,
+                    "is_player": city_name is not None,
+                    "session_key": session_key,
+                    "session_display": session_display,
+                    "resident_total": isl.resident_total,
+                    "residence_count": (residence.residence_count if residence is not None else 0),
+                    "avg_saturation_mean": (
+                        residence.avg_saturation_mean if residence is not None else float("nan")
+                    ),
+                    "deficit_count": sum(1 for p in isl.products if p.is_deficit),
+                }
+            )
+    return _make_df(rows, _ISLANDS_COLUMNS)
+
+
+def _tiers_df(state: TuiState, islands_df: pd.DataFrame) -> pd.DataFrame:
+    residences_by_am = {agg.area_manager: agg for agg in state.population_by_city.values()}
+    # city_name lookup 用に islands_df を使う (join より明示的)
+    city_by_am = dict(zip(islands_df["area_manager"], islands_df["city_name"], strict=False))
+
+    rows: list[dict] = []
+    for am, agg in residences_by_am.items():
+        for ts in agg.tier_breakdown:
+            rows.append(
+                {
+                    "area_manager": am,
+                    "city_name": city_by_am.get(am),
+                    "tier": ts.tier,
+                    "residence_count": ts.residence_count,
+                    "resident_total": ts.resident_total,
+                    "avg_saturation_mean": ts.avg_saturation_mean,
+                }
+            )
+    return _make_df(rows, _TIERS_COLUMNS)
+
+
+def _balance_df(state: TuiState, islands_df: pd.DataFrame) -> pd.DataFrame:
+    balance = state.balance_table
+    if balance is None:
+        return _make_df([], _BALANCE_COLUMNS)
+    city_by_am = dict(zip(islands_df["area_manager"], islands_df["city_name"], strict=False))
+
+    rows: list[dict] = []
+    for isl in balance.islands:
+        for p in isl.products:
+            item = state.items[p.product_guid]
+            name = item.display_name(state.locale) or f"Good_{p.product_guid}"
+            rows.append(
+                {
+                    "area_manager": isl.area_manager,
+                    "city_name": city_by_am.get(isl.area_manager),
+                    "product_guid": p.product_guid,
+                    "product_name": name,
+                    "produced_per_minute": p.produced_per_minute,
+                    "consumed_per_minute": p.consumed_per_minute,
+                    "delta_per_minute": p.delta_per_minute,
+                    "is_deficit": p.is_deficit,
+                }
+            )
+    return _make_df(rows, _BALANCE_COLUMNS)
+
+
+def _trade_events_df(state: TuiState) -> pd.DataFrame:
+    rows: list[dict] = []
+    for ev in state.events:
+        item_name = ev.item.display_name(state.locale) or f"Good_{ev.item.guid}"
+        rows.append(
+            {
+                "timestamp_tick": ev.timestamp_tick,
+                "product_guid": ev.item.guid,
+                "product_name": item_name,
+                "amount": ev.amount,
+                "total_price": ev.total_price,
+                "session_id": ev.session_id,
+                "island_name": ev.island_name,
+                "route_id": ev.route_id,
+                "route_name": ev.route_name,
+                "partner_id": ev.partner.id if ev.partner else None,
+                "partner_kind": ev.partner.kind if ev.partner else None,
+                "source_method": ev.source_method,
+            }
+        )
+    df = _make_df(rows, _TRADE_EVENT_COLUMNS)
+    # timestamp_tick は NaN 混ざりうるので pandas の nullable Int64 に揃える
+    if not df.empty:
+        df = df.astype({"timestamp_tick": "Int64"})
+    return df
+
+
+def _make_df(rows: list[dict], columns: tuple[str, ...]) -> pd.DataFrame:
+    """空でも column schema を保持する DataFrame を返す．"""
+    if not rows:
+        return pd.DataFrame(columns=list(columns))
+    return pd.DataFrame(rows, columns=list(columns))

--- a/tests/analysis/conftest.py
+++ b/tests/analysis/conftest.py
@@ -1,0 +1,45 @@
+"""analysis test 用 fixture．TUI test 側と同じ合成 Anno 117 state を流用．
+
+本来は tests/conftest.py に一本化すべきだが，既存 tests/tui/conftest.py と
+tests/gui/conftest.py の相互関係を変えると blast radius が広いため一旦
+コピー．別 chore PR で統合する．
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from anno_save_analyzer.trade import GameTitle, ItemDictionary
+from anno_save_analyzer.tui.state import TuiState, load_state
+from tests.trade.conftest import make_inner_filedb, wrap_as_outer
+
+
+def _items(tmp_path: Path) -> ItemDictionary:
+    title = "anno117"
+    en = tmp_path / f"items_{title}.en.yaml"
+    en.write_text(
+        "100:\n  name: Wood\n  category: raw\n200:\n  name: Bricks\n",
+        encoding="utf-8",
+    )
+    ja = tmp_path / f"items_{title}.ja.yaml"
+    ja.write_text("100:\n  name: 木材\n200:\n  name: 煉瓦\n", encoding="utf-8")
+    return ItemDictionary.load(GameTitle.ANNO_117, locales=["en", "ja"], data_dir=tmp_path)
+
+
+@pytest.fixture
+def tui_state(tmp_path: Path) -> TuiState:
+    inner_a = make_inner_filedb(
+        {
+            "route": [(7, 100, 5, 0), (7, 200, -3, 0)],
+            "passive": [(99, 100, 1, -10)],
+        }
+    )
+    inner_b = make_inner_filedb({"route": [(8, 200, 2, 0)]})
+    outer = wrap_as_outer([inner_a, inner_b])
+    save = tmp_path / "fake.bin"
+    save.write_bytes(outer)
+
+    items = _items(tmp_path)
+    return load_state(save, title=GameTitle.ANNO_117, locale="en", items=items)

--- a/tests/analysis/test_frames.py
+++ b/tests/analysis/test_frames.py
@@ -1,0 +1,264 @@
+"""``analysis.frames.to_frames`` のテスト．
+
+pandas DataFrame 4 本が正しく構築されるかと，title 非依存性 (Anno 117 /
+balance 無し) が保たれるかを確認する．
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from anno_save_analyzer.analysis import to_frames
+from anno_save_analyzer.trade.balance import (
+    IslandBalance,
+    ProductBalance,
+    SupplyBalanceTable,
+)
+from anno_save_analyzer.trade.models import GameTitle
+from anno_save_analyzer.trade.population import (
+    ProductSaturation,
+    ResidenceAggregate,
+    TierSummary,
+)
+from anno_save_analyzer.tui.state import TuiState
+
+# ---------- fixtures ----------
+
+
+def _mk_balance_table() -> SupplyBalanceTable:
+    return SupplyBalanceTable(
+        islands=(
+            IslandBalance(
+                area_manager="AreaManager_1",
+                city_name="岡山",
+                resident_total=1000,
+                products=(
+                    ProductBalance(
+                        product_guid=200, produced_per_minute=4.0, consumed_per_minute=1.5
+                    ),
+                    ProductBalance(
+                        product_guid=300, produced_per_minute=0.5, consumed_per_minute=2.0
+                    ),
+                ),
+            ),
+            IslandBalance(
+                area_manager="AreaManager_2",
+                city_name=None,
+                resident_total=500,
+                products=(
+                    ProductBalance(
+                        product_guid=200, produced_per_minute=2.0, consumed_per_minute=1.0
+                    ),
+                ),
+            ),
+        )
+    )
+
+
+def _inject_balance(state: TuiState) -> TuiState:
+    """既存 tui_state fixture (Anno 117) に Anno 1800 の balance を追加差し込み．"""
+    return dataclasses.replace(
+        state,
+        title=GameTitle.ANNO_1800,
+        balance_table=_mk_balance_table(),
+        area_manager_to_session_key={
+            "AreaManager_1": "session.anno1800.old_world",
+            "AreaManager_2": "session.anno1800.cape_trelawney",
+        },
+        area_manager_to_city={"AreaManager_1": "岡山"},
+        population_by_city={
+            "岡山": ResidenceAggregate(
+                area_manager="AreaManager_1",
+                residence_count=100,
+                resident_total=1000,
+                avg_saturation_mean=0.7,
+                product_saturations=(
+                    ProductSaturation(product_guid=200, current=0.9, average=0.85),
+                ),
+                tier_breakdown=(
+                    TierSummary(
+                        tier="farmer",
+                        residence_count=60,
+                        resident_total=600,
+                        avg_saturation_mean=0.8,
+                    ),
+                    TierSummary(
+                        tier="worker",
+                        residence_count=40,
+                        resident_total=400,
+                        avg_saturation_mean=0.55,
+                    ),
+                ),
+            ),
+        },
+    )
+
+
+# ---------- Islands DataFrame ----------
+
+
+class TestIslandsFrame:
+    def test_one_row_per_island(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        assert len(frames.islands) == 2
+
+    def test_columns_schema(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        expected = {
+            "area_manager",
+            "city_name",
+            "is_player",
+            "session_key",
+            "session_display",
+            "resident_total",
+            "residence_count",
+            "avg_saturation_mean",
+            "deficit_count",
+        }
+        assert set(frames.islands.columns) == expected
+
+    def test_player_vs_npc_flag(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        by_am = frames.islands.set_index("area_manager")
+        assert (
+            by_am.loc["AreaManager_1", "is_player"] is True
+            or by_am.loc["AreaManager_1", "is_player"]
+        )
+        assert not by_am.loc["AreaManager_2", "is_player"]
+
+    def test_session_display_resolved(self, tui_state) -> None:
+        """Localizer で session_key → display 解決されてる．"""
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        displays = set(frames.islands["session_display"].dropna())
+        # 旧世界 / トレローニー岬 (ja locale) or Old World / Cape Trelawney (en)
+        assert any("Old World" in d or "旧世界" in d for d in displays)
+
+    def test_deficit_count(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        by_am = frames.islands.set_index("area_manager")
+        # AreaManager_1: product 300 で deficit (0.5 vs 2.0)
+        assert by_am.loc["AreaManager_1", "deficit_count"] == 1
+        # AreaManager_2: 黒字のみ
+        assert by_am.loc["AreaManager_2", "deficit_count"] == 0
+
+
+# ---------- Tiers DataFrame ----------
+
+
+class TestTiersFrame:
+    def test_tier_rows_per_island(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        # AreaManager_1 に farmer + worker 2 tier
+        assert len(frames.tiers) == 2
+
+    def test_residents_per_tier(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        by_tier = frames.tiers.set_index("tier")
+        assert by_tier.loc["farmer", "resident_total"] == 600
+        assert by_tier.loc["worker", "resident_total"] == 400
+
+
+# ---------- Balance DataFrame ----------
+
+
+class TestBalanceFrame:
+    def test_rows_per_island_product(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        # AreaManager_1: 2 product, AreaManager_2: 1 product
+        assert len(frames.balance) == 3
+
+    def test_delta_column(self, tui_state) -> None:
+        state = _inject_balance(tui_state)
+        frames = to_frames(state)
+        # AreaManager_1 product 300 は delta = 0.5 - 2.0 = -1.5
+        mask = (frames.balance["area_manager"] == "AreaManager_1") & (
+            frames.balance["product_guid"] == 300
+        )
+        row = frames.balance[mask].iloc[0]
+        assert row["delta_per_minute"] == pytest.approx(-1.5)
+        assert bool(row["is_deficit"]) is True
+
+
+# ---------- TradeEvents DataFrame ----------
+
+
+class TestTradeEventsFrame:
+    def test_columns_include_route_and_partner(self, tui_state) -> None:
+        frames = to_frames(tui_state)
+        expected = {
+            "timestamp_tick",
+            "product_guid",
+            "product_name",
+            "amount",
+            "total_price",
+            "session_id",
+            "island_name",
+            "route_id",
+            "route_name",
+            "partner_id",
+            "partner_kind",
+            "source_method",
+        }
+        assert set(frames.trade_events.columns) == expected
+
+    def test_has_events(self, tui_state) -> None:
+        frames = to_frames(tui_state)
+        # tui_state fixture は複数 TradeEvent を含む合成 save
+        assert len(frames.trade_events) > 0
+
+    def test_timestamp_tick_is_nullable_int(self, tui_state) -> None:
+        frames = to_frames(tui_state)
+        if not frames.trade_events.empty:
+            # pandas の Int64 拡張型が使われてる (nullable)
+            assert str(frames.trade_events["timestamp_tick"].dtype) == "Int64"
+
+
+# ---------- title 非依存 (Anno 117 / balance 無し) ----------
+
+
+class TestTitleAgnostic:
+    def test_anno117_no_balance_yields_empty_schema(self, tui_state) -> None:
+        """Anno 117 fixture (balance_table=None) でも DataFrame schema は維持．"""
+        # tui_state fixture そのまま Anno 117
+        frames = to_frames(tui_state)
+        assert list(frames.islands.columns) == [
+            "area_manager",
+            "city_name",
+            "is_player",
+            "session_key",
+            "session_display",
+            "resident_total",
+            "residence_count",
+            "avg_saturation_mean",
+            "deficit_count",
+        ]
+        # balance_table=None なので islands は空
+        assert frames.islands.empty
+        # balance も空
+        assert frames.balance.empty
+
+    def test_empty_inputs_keep_columns(self, tmp_path: Path, tui_state) -> None:
+        """空 state でも DataFrame が crash せず空を返す．"""
+        state = dataclasses.replace(tui_state, events=(), population_by_city={}, balance_table=None)
+        frames = to_frames(state)
+        assert frames.islands.empty
+        assert frames.tiers.empty
+        assert frames.balance.empty
+        assert frames.trade_events.empty
+
+
+# ---------- conftest ---------
+
+# tui_state fixture は tests/tui/conftest.py で定義．analysis は TUI に依存
+# しないため，test 用にそちらの fixture を流用する conftest を用意．


### PR DESCRIPTION
## Summary

v0.5 SCM Analytics milestone の**前提** module (Issue #81-A)．
``anno_save_analyzer.analysis`` 配下に ``to_frames`` を新設し，``TuiState``
を 4 本の正規化された pandas DataFrame に変換する．後続 analyzer B-J は
全てこの表現を入力に取る．

## API

```python
from anno_save_analyzer.analysis import to_frames
from anno_save_analyzer.tui.state import load_state

state = load_state(save_path, title=GameTitle.ANNO_1800, locale="ja")
frames = to_frames(state)

frames.islands        # 1 row = 1 AreaManager
frames.tiers          # 1 row = 1 (island, tier)
frames.balance        # 1 row = 1 (island, product)
frames.trade_events   # 1 row = 1 event
```

## DataFrames schema

| frame | rows | 主なカラム |
|---|---|---|
| ``islands`` | N islands | ``area_manager``, ``city_name``, ``is_player``, ``session_display``, ``resident_total``, ``deficit_count`` ... |
| ``tiers`` | N × M (tier) | ``area_manager``, ``tier``, ``resident_total``, ``avg_saturation_mean`` |
| ``balance`` | N × P (product) | ``area_manager``, ``product_guid``, ``product_name``, ``produced_per_minute``, ``consumed_per_minute``, ``delta_per_minute``, ``is_deficit`` |
| ``trade_events`` | E events | ``timestamp_tick`` (Int64), ``product_guid``, ``amount``, ``total_price``, ``session_id``, ``route_id``, ``partner_kind``... |

## Title 非依存

- Anno 117 / Anno 1800 両対応
- ``balance_table`` が ``None`` (117 / YAML 欠損) でも schema を維持した空 DataFrame
- session 表示は Localizer で title 別解決 (「トレローニー岬」)

## Test plan

- [x] ``tests/analysis/test_frames.py`` 14 件 — column schema / player-NPC
      分類 / session resolver / deficit count / tier breakdown / balance
      delta / Int64 dtype / Anno 117 空 state / 完全空 state
- [x] 全体 pytest 639 passed / coverage 維持
- [x] ruff check + format clean

## 次 (各別 PR)

[B #82] deficit heatmap + Pareto / [C #83] saturation 相関 /
[D #84] route ランキング / [E #85] 慢性/一過性分類 /
[F #86] 船1隻減らす感度分析 / [G #87] 人口 forecast /
[**H #88** 書記長本命] Decision Matrix / [I #89] Min-Cost Flow /
[J #13] VRP (MILP)

Refs: #81