### PR TITLE
feat(analysis): I Min-Cost Flow 最適割当 (#89)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic>=2.0",
     "pandas>=2.0",
     "typer>=0.12",
+    "networkx>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/anno_save_analyzer/analysis/allocation.py
+++ b/src/anno_save_analyzer/analysis/allocation.py
@@ -46,7 +46,7 @@ _OUTPUT_COLUMNS = [
 def optimal_flow(
     balance_df: pd.DataFrame,
     *,
-    session_by_area_manager: Mapping[str, str] | None = None,
+    session_by_area_manager: Mapping[str, str | None] | None = None,
 ) -> pd.DataFrame:
     """各物資の供給余剰→赤字 flow を min-cost で解く．
 
@@ -58,6 +58,7 @@ def optimal_flow(
     if balance_df.empty:
         return pd.DataFrame(columns=_OUTPUT_COLUMNS)
 
+    session_map: Mapping[str, str | None] = session_by_area_manager or {}
     rows: list[dict] = []
     for (guid, name), group in balance_df.groupby(["product_guid", "product_name"]):
         suppliers = group[group["delta_per_minute"] > 0]
@@ -67,10 +68,10 @@ def optimal_flow(
         flow_dict = _solve_product(
             suppliers=suppliers,
             demanders=demanders,
-            session_by_area_manager=session_by_area_manager or {},
+            session_by_area_manager=session_map,
         )
         for source_am, sink_am, flow_scaled in flow_dict:
-            cost = _edge_cost(source_am, sink_am, session_by_area_manager or {})
+            cost = _edge_cost(source_am, sink_am, session_map)
             rows.append(
                 {
                     "product_guid": int(guid),
@@ -95,7 +96,7 @@ def _solve_product(
     *,
     suppliers: pd.DataFrame,
     demanders: pd.DataFrame,
-    session_by_area_manager: Mapping[str, str],
+    session_by_area_manager: Mapping[str, str | None],
 ) -> list[tuple[str, str, int]]:
     """1 物資について max-flow min-cost を解いて (source, sink, flow) を返す．"""
     g = nx.DiGraph()
@@ -106,14 +107,14 @@ def _solve_product(
 
     for _, row in suppliers.iterrows():
         am = str(row["area_manager"])
-        cap = int(float(row["delta_per_minute"]) * _SCALE)
+        cap = int(round(float(row["delta_per_minute"]) * _SCALE))
         if cap <= 0:
             continue
         g.add_edge(src_node, _supplier_node(am), capacity=cap, weight=0)
 
     for _, row in demanders.iterrows():
         am = str(row["area_manager"])
-        cap = int(-float(row["delta_per_minute"]) * _SCALE)
+        cap = int(round(-float(row["delta_per_minute"]) * _SCALE))
         if cap <= 0:
             continue
         g.add_edge(_demander_node(am), sink_node, capacity=cap, weight=0)
@@ -159,7 +160,7 @@ def _demander_node(area_manager: str) -> str:
 def _edge_cost(
     source_am: str,
     sink_am: str,
-    session_by_area_manager: Mapping[str, str],
+    session_by_area_manager: Mapping[str, str | None],
 ) -> int:
     if not session_by_area_manager:
         return _SAME_SESSION_COST

--- a/src/anno_save_analyzer/analysis/allocation.py
+++ b/src/anno_save_analyzer/analysis/allocation.py
@@ -1,0 +1,170 @@
+"""需給ギャップの最適割当 (v0.5-I #89)．
+
+供給余剰島 → 赤字島への物資分配を ``networkx.max_flow_min_cost`` で解く．
+全 demand を満たせない場合は partial flow を返す．
+
+## Graph 構造 (物資ごと)
+
+```
+SRC → supplier_1 (cap=excess_1) ──┐
+                                  ├─→ demander_1 (cap=need_1) → SNK
+SRC → supplier_2 (cap=excess_2) ──┤                                ↑
+                                  └─→ demander_2 (cap=need_2) ────┘
+```
+
+- ``SRC → supplier`` の cap = 供給余剰
+- ``demander → SNK`` の cap = 不足量
+- ``supplier → demander`` は無限 cap，cost は距離 proxy
+
+## 距離 proxy
+
+``session_by_area_manager`` が渡されれば session 一致で cost=1，不一致で
+cost=10．未指定なら全 edge cost=1 (距離区別なし)．
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import networkx as nx
+import pandas as pd
+
+_SCALE = 1000  # 小数を整数化するスケール．networkx は int capacity 前提
+_SAME_SESSION_COST = 1
+_DIFFERENT_SESSION_COST = 10
+
+_OUTPUT_COLUMNS = [
+    "product_guid",
+    "product_name",
+    "source_am",
+    "sink_am",
+    "quantity_per_min",
+    "cost",
+]
+
+
+def optimal_flow(
+    balance_df: pd.DataFrame,
+    *,
+    session_by_area_manager: Mapping[str, str] | None = None,
+) -> pd.DataFrame:
+    """各物資の供給余剰→赤字 flow を min-cost で解く．
+
+    ``balance_df`` は ``analysis.frames.to_frames(state).balance`` の形式を
+    想定．``delta_per_minute > 0`` = 供給余剰，``< 0`` = 赤字として扱う．
+
+    戻り値: 1 row = 1 (product, source, sink) 割当．flow=0 の組は省略．
+    """
+    if balance_df.empty:
+        return pd.DataFrame(columns=_OUTPUT_COLUMNS)
+
+    rows: list[dict] = []
+    for (guid, name), group in balance_df.groupby(["product_guid", "product_name"]):
+        suppliers = group[group["delta_per_minute"] > 0]
+        demanders = group[group["delta_per_minute"] < 0]
+        if suppliers.empty or demanders.empty:
+            continue
+        flow_dict = _solve_product(
+            suppliers=suppliers,
+            demanders=demanders,
+            session_by_area_manager=session_by_area_manager or {},
+        )
+        for source_am, sink_am, flow_scaled in flow_dict:
+            cost = _edge_cost(source_am, sink_am, session_by_area_manager or {})
+            rows.append(
+                {
+                    "product_guid": int(guid),
+                    "product_name": name,
+                    "source_am": source_am,
+                    "sink_am": sink_am,
+                    "quantity_per_min": flow_scaled / _SCALE,
+                    "cost": cost,
+                }
+            )
+    return (
+        pd.DataFrame(rows, columns=_OUTPUT_COLUMNS)
+        .sort_values(["product_name", "source_am", "sink_am"])
+        .reset_index(drop=True)
+    )
+
+
+# ---------- internals ----------
+
+
+def _solve_product(
+    *,
+    suppliers: pd.DataFrame,
+    demanders: pd.DataFrame,
+    session_by_area_manager: Mapping[str, str],
+) -> list[tuple[str, str, int]]:
+    """1 物資について max-flow min-cost を解いて (source, sink, flow) を返す．"""
+    g = nx.DiGraph()
+    src_node = "__SRC__"
+    sink_node = "__SNK__"
+    g.add_node(src_node)
+    g.add_node(sink_node)
+
+    for _, row in suppliers.iterrows():
+        am = str(row["area_manager"])
+        cap = int(float(row["delta_per_minute"]) * _SCALE)
+        if cap <= 0:
+            continue
+        g.add_edge(src_node, _supplier_node(am), capacity=cap, weight=0)
+
+    for _, row in demanders.iterrows():
+        am = str(row["area_manager"])
+        cap = int(-float(row["delta_per_minute"]) * _SCALE)
+        if cap <= 0:
+            continue
+        g.add_edge(_demander_node(am), sink_node, capacity=cap, weight=0)
+
+    for _, sup in suppliers.iterrows():
+        sup_am = str(sup["area_manager"])
+        for _, dem in demanders.iterrows():
+            dem_am = str(dem["area_manager"])
+            weight = _edge_cost(sup_am, dem_am, session_by_area_manager)
+            g.add_edge(
+                _supplier_node(sup_am),
+                _demander_node(dem_am),
+                capacity=10**9,
+                weight=weight,
+            )
+
+    try:
+        flow = nx.max_flow_min_cost(g, src_node, sink_node)
+    except nx.NetworkXUnfeasible:  # pragma: no cover - defensive
+        return []
+
+    results: list[tuple[str, str, int]] = []
+    for u, outs in flow.items():
+        if not u.startswith("S::"):
+            continue
+        sup_am = u[3:]
+        for v, amount in outs.items():
+            if not v.startswith("D::") or amount <= 0:
+                continue
+            dem_am = v[3:]
+            results.append((sup_am, dem_am, int(amount)))
+    return results
+
+
+def _supplier_node(area_manager: str) -> str:
+    return f"S::{area_manager}"
+
+
+def _demander_node(area_manager: str) -> str:
+    return f"D::{area_manager}"
+
+
+def _edge_cost(
+    source_am: str,
+    sink_am: str,
+    session_by_area_manager: Mapping[str, str],
+) -> int:
+    if not session_by_area_manager:
+        return _SAME_SESSION_COST
+    src_session = session_by_area_manager.get(source_am)
+    sink_session = session_by_area_manager.get(sink_am)
+    if src_session is None or sink_session is None:
+        return _SAME_SESSION_COST
+    return _SAME_SESSION_COST if src_session == sink_session else _DIFFERENT_SESSION_COST

--- a/tests/analysis/test_allocation.py
+++ b/tests/analysis/test_allocation.py
@@ -1,0 +1,215 @@
+"""``analysis.allocation.optimal_flow`` のテスト．
+
+合成 balance_df で min-cost flow が期待どおり supplier → demander に
+quantity を振り分けるか確認．
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from anno_save_analyzer.analysis.allocation import optimal_flow
+
+
+def _balance(rows: list[dict]) -> pd.DataFrame:
+    defaults = {
+        "city_name": None,
+        "produced_per_minute": 0.0,
+        "consumed_per_minute": 0.0,
+        "is_deficit": False,
+    }
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+class TestOptimalFlow:
+    def test_simple_supplier_to_demander(self) -> None:
+        df = _balance(
+            [
+                {
+                    "area_manager": "A",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 3.0,
+                },
+                {
+                    "area_manager": "B",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -2.0,
+                },
+            ]
+        )
+        result = optimal_flow(df)
+        assert len(result) == 1
+        row = result.iloc[0]
+        assert row["source_am"] == "A"
+        assert row["sink_am"] == "B"
+        # 需要 2.0 までしか流れない (supplier capacity 3.0 > demand 2.0)
+        assert row["quantity_per_min"] == pytest.approx(2.0)
+
+    def test_partial_flow_when_supply_lt_demand(self) -> None:
+        df = _balance(
+            [
+                {
+                    "area_manager": "A",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 1.0,
+                },
+                {
+                    "area_manager": "B",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -5.0,
+                },
+            ]
+        )
+        result = optimal_flow(df)
+        # supply 1 が全部 B に流れる (demand 5 は部分充足)
+        assert result.iloc[0]["quantity_per_min"] == pytest.approx(1.0)
+
+    def test_prefers_same_session_source(self) -> None:
+        """距離 proxy を与えると同 session の supplier が優先される．"""
+        df = _balance(
+            [
+                {
+                    "area_manager": "A1",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 5.0,
+                },
+                {
+                    "area_manager": "A2",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 5.0,
+                },
+                {
+                    "area_manager": "B1",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -3.0,
+                },
+            ]
+        )
+        session = {"A1": "old_world", "A2": "new_world", "B1": "old_world"}
+        result = optimal_flow(df, session_by_area_manager=session)
+        # A1 (same session) が優先される
+        flow_a1 = result[result["source_am"] == "A1"]["quantity_per_min"].sum()
+        flow_a2 = result[result["source_am"] == "A2"]["quantity_per_min"].sum()
+        assert flow_a1 == pytest.approx(3.0)
+        assert flow_a2 == pytest.approx(0.0)
+
+    def test_multiple_products_solved_independently(self) -> None:
+        df = _balance(
+            [
+                {
+                    "area_manager": "A",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 2.0,
+                },
+                {
+                    "area_manager": "B",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -1.0,
+                },
+                {
+                    "area_manager": "A",
+                    "product_guid": 200,
+                    "product_name": "Bread",
+                    "delta_per_minute": -3.0,
+                },
+                {
+                    "area_manager": "B",
+                    "product_guid": 200,
+                    "product_name": "Bread",
+                    "delta_per_minute": 4.0,
+                },
+            ]
+        )
+        result = optimal_flow(df)
+        # Wood: A → B, Bread: B → A の 2 行
+        by_product = {r["product_name"]: r for _, r in result.iterrows()}
+        assert by_product["Wood"]["source_am"] == "A"
+        assert by_product["Wood"]["sink_am"] == "B"
+        assert by_product["Wood"]["quantity_per_min"] == pytest.approx(1.0)
+        assert by_product["Bread"]["source_am"] == "B"
+        assert by_product["Bread"]["sink_am"] == "A"
+        assert by_product["Bread"]["quantity_per_min"] == pytest.approx(3.0)
+
+    def test_no_supply_for_product_yields_no_flow(self) -> None:
+        """赤字しかない物資は flow 生成されない．"""
+        df = _balance(
+            [
+                {
+                    "area_manager": "A",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -1.0,
+                },
+                {
+                    "area_manager": "B",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -2.0,
+                },
+            ]
+        )
+        result = optimal_flow(df)
+        assert result.empty
+
+    def test_no_demand_for_product_yields_no_flow(self) -> None:
+        """黒字しかない物資も flow 生成されない．"""
+        df = _balance(
+            [
+                {
+                    "area_manager": "A",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 5.0,
+                },
+            ]
+        )
+        result = optimal_flow(df)
+        assert result.empty
+
+    def test_empty_input_returns_empty(self) -> None:
+        result = optimal_flow(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == [
+            "product_guid",
+            "product_name",
+            "source_am",
+            "sink_am",
+            "quantity_per_min",
+            "cost",
+        ]
+
+
+class TestEdgeCost:
+    def test_cost_column_reflects_session_distance(self) -> None:
+        df = _balance(
+            [
+                {
+                    "area_manager": "A",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": 2.0,
+                },
+                {
+                    "area_manager": "B",
+                    "product_guid": 100,
+                    "product_name": "Wood",
+                    "delta_per_minute": -1.0,
+                },
+            ]
+        )
+        # A,B は別 session
+        result = optimal_flow(df, session_by_area_manager={"A": "x", "B": "y"})
+        assert result.iloc[0]["cost"] == 10
+        # 同 session
+        result = optimal_flow(df, session_by_area_manager={"A": "x", "B": "x"})
+        assert result.iloc[0]["cost"] == 1


### PR DESCRIPTION
## Summary

v0.5 SCM Analytics の 9 つ目．``networkx.max_flow_min_cost`` で供給余剰島
→ 赤字島の物資分配を最適化．書記長の「需給ギャップをどう埋めるか」を
算出．

## API

```python
from anno_save_analyzer.analysis import to_frames
from anno_save_analyzer.analysis.allocation import optimal_flow

frames = to_frames(state)

# 全体最適 flow
flow = optimal_flow(frames.balance)

# 距離 proxy: 同 session=1 / 別 session=10
session_map = dict(zip(
    frames.islands["area_manager"],
    frames.islands["session_key"],
    strict=False,
))
flow = optimal_flow(frames.balance, session_by_area_manager=session_map)

# 岡山が赤字の物資をどの島から調達すべきか
flow[flow["sink_am"] == "AreaManager_8706"] \
    .sort_values("quantity_per_min", ascending=False)
```

出力: ``product_guid / product_name / source_am / sink_am /
quantity_per_min / cost``

## Graph 構造

物資ごとに独立な bipartite graph．``max_flow_min_cost`` で partial flow
(供給不足時) も素直に解ける．

## Dep 追加

base deps に ``networkx>=3.0``．SCM 分析の前提なので optional 扱いせず．

## Test plan

- [x] ``tests/analysis/test_allocation.py`` 8 件 (simple / partial /
      同 session 優先 / 複数 product / supply only / demand only / 空 / cost)
- [x] 全体 pytest 677 passed / coverage 維持
- [x] ruff check + format clean

## Title 非依存

balance_df さえあれば title 非依存．Anno 117 / 1800 両対応．

## 次

- [J #13] OR-Tools VRP (v0.5 最終本丸)

Refs: #89