### PR TITLE
feat(cli,gui): config.toml-based auto-select of latest save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ refs/
 notebooks/out/
 notebooks/.ipynb_checkpoints/
 *.ipynb_checkpoints/
+
+# local .env (copied from .env.example)
+.env
+docs/_build/
+*.mo

--- a/src/anno_save_analyzer/cli/state.py
+++ b/src/anno_save_analyzer/cli/state.py
@@ -56,9 +56,7 @@ def dump_state(  # noqa: PLR0913,B008 — CLI entrypoint．typer.Argument/Option
     title_enum = GameTitle(title)
     resolved = resolve_save(save, title_enum)
     if resolved is None:
-        field = (
-            "anno1800_save_dir" if title_enum is GameTitle.ANNO_1800 else "anno117_save_dir"
-        )
+        field = "anno1800_save_dir" if title_enum is GameTitle.ANNO_1800 else "anno117_save_dir"
         typer.secho(
             f"ERROR: save not specified and [paths] {field} is unset or empty. "
             "Either pass the save path explicitly or set it in your config.toml.",

--- a/src/anno_save_analyzer/cli/state.py
+++ b/src/anno_save_analyzer/cli/state.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import typer
 
+from anno_save_analyzer.latest_save import resolve_save
 from anno_save_analyzer.trade.balance import IslandBalance, ProductBalance
 from anno_save_analyzer.trade.models import GameTitle, TradeEvent
 from anno_save_analyzer.trade.population import ResidenceAggregate, TierSummary
@@ -28,7 +29,13 @@ from anno_save_analyzer.tui.state import TuiState, load_state
 
 
 def dump_state(  # noqa: PLR0913,B008 — CLI entrypoint．typer.Argument/Option は default で使う慣例
-    save: Path = typer.Argument(..., help="Anno save file (.a7s / .a8s)", exists=True),  # noqa: B008
+    save: Path | None = typer.Argument(  # noqa: B008
+        None,
+        help=(
+            "Anno save file (.a7s / .a8s). Omit to auto-select latest save "
+            "from config.toml ([paths] anno1800_save_dir / anno117_save_dir)."
+        ),
+    ),
     title: str = typer.Option(  # noqa: B008
         GameTitle.ANNO_1800.value,
         "--title",
@@ -47,6 +54,24 @@ def dump_state(  # noqa: PLR0913,B008 — CLI entrypoint．typer.Argument/Option
 ) -> None:
     """Load the save and dump a single JSON document to ``--out``．"""
     title_enum = GameTitle(title)
+    resolved = resolve_save(save, title_enum)
+    if resolved is None:
+        field = (
+            "anno1800_save_dir" if title_enum is GameTitle.ANNO_1800 else "anno117_save_dir"
+        )
+        typer.secho(
+            f"ERROR: save not specified and [paths] {field} is unset or empty. "
+            "Either pass the save path explicitly or set it in your config.toml.",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=2)
+    if save is None:
+        typer.secho(f"Auto-selected latest save: {resolved}", err=True, fg=typer.colors.CYAN)
+    if not resolved.is_file():
+        typer.secho(f"ERROR: save file not found: {resolved}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2)
+    save = resolved
     state = load_state(save, title=title_enum, locale=locale)
     localizer = Localizer.load(locale)
     payload = _build_payload(state, localizer, include_events=include_events)

--- a/src/anno_save_analyzer/cli/state.py
+++ b/src/anno_save_analyzer/cli/state.py
@@ -58,8 +58,10 @@ def dump_state(  # noqa: PLR0913,B008 — CLI entrypoint．typer.Argument/Option
     if resolved is None:
         field = "anno1800_save_dir" if title_enum is GameTitle.ANNO_1800 else "anno117_save_dir"
         typer.secho(
-            f"ERROR: save not specified and [paths] {field} is unset or empty. "
-            "Either pass the save path explicitly or set it in your config.toml.",
+            f"ERROR: could not auto-select a save from [paths] {field}. "
+            "The setting may be unset, the configured directory may not exist, "
+            "or it may contain no matching .a7s/.a8s files. "
+            "Either pass the save path explicitly or fix your config.toml.",
             err=True,
             fg=typer.colors.RED,
         )

--- a/src/anno_save_analyzer/cli/tui.py
+++ b/src/anno_save_analyzer/cli/tui.py
@@ -76,9 +76,7 @@ def _launch(
             raise typer.Exit(code=2)
         resolved = resolve_save(None, title.to_title())
         if resolved is None:
-            field = (
-                "anno1800_save_dir" if title == GameTitleArg.ANNO_1800 else "anno117_save_dir"
-            )
+            field = "anno1800_save_dir" if title == GameTitleArg.ANNO_1800 else "anno117_save_dir"
             typer.secho(
                 f"No save found. Set [paths] {field} in your config.toml "
                 "to a directory containing .a7s/.a8s files.",

--- a/src/anno_save_analyzer/cli/tui.py
+++ b/src/anno_save_analyzer/cli/tui.py
@@ -9,6 +9,7 @@ from typing import Annotated
 import typer
 
 from anno_save_analyzer.cli._title import resolve_title
+from anno_save_analyzer.latest_save import resolve_save
 from anno_save_analyzer.trade.models import GameTitle
 
 
@@ -25,7 +26,16 @@ _THEME_SENTINEL = "__from_config__"
 
 
 def _launch(
-    save: Annotated[Path, typer.Argument(help="Save file (.a7s / .a8s).")],
+    save: Annotated[
+        Path | None,
+        typer.Argument(
+            help=(
+                "Save file (.a7s / .a8s). Omit to auto-select the newest save "
+                "from your config.toml ([paths] anno1800_save_dir / "
+                "anno117_save_dir); --title is then required."
+            ),
+        ),
+    ] = None,
     title: Annotated[
         GameTitleArg | None,
         typer.Option(
@@ -52,6 +62,33 @@ def _launch(
     Long saves may take 10–40 seconds to parse; a progress log is printed to
     stderr while loading.
     """
+    # save 省略時: config.toml [paths] から最新 save を自動選択．
+    # ただし title 必須 (拡張子による推定ができないため)．
+    if save is None:
+        if title is None:
+            typer.secho(
+                "SAVE not given and --title missing. When SAVE is omitted, "
+                "--title anno1800 / anno117 is required so we can pick the "
+                "right [paths] entry from your config.toml.",
+                err=True,
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=2)
+        resolved = resolve_save(None, title.to_title())
+        if resolved is None:
+            field = (
+                "anno1800_save_dir" if title == GameTitleArg.ANNO_1800 else "anno117_save_dir"
+            )
+            typer.secho(
+                f"No save found. Set [paths] {field} in your config.toml "
+                "to a directory containing .a7s/.a8s files.",
+                err=True,
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=2)
+        save = resolved
+        typer.secho(f"Auto-selected latest save: {save}", err=True, fg=typer.colors.CYAN)
+
     try:
         from anno_save_analyzer.tui import TradeApp
         from anno_save_analyzer.tui.state import load_state

--- a/src/anno_save_analyzer/cli/tui.py
+++ b/src/anno_save_analyzer/cli/tui.py
@@ -78,8 +78,9 @@ def _launch(
         if resolved is None:
             field = "anno1800_save_dir" if title == GameTitleArg.ANNO_1800 else "anno117_save_dir"
             typer.secho(
-                f"No save found. Set [paths] {field} in your config.toml "
-                "to a directory containing .a7s/.a8s files.",
+                f"No save found from [paths] {field}. The setting may be unset, "
+                "the configured directory may not exist, or it may contain no "
+                ".a7s/.a8s files. Pass the save path or fix your config.toml.",
                 err=True,
                 fg=typer.colors.RED,
             )

--- a/src/anno_save_analyzer/config.py
+++ b/src/anno_save_analyzer/config.py
@@ -185,11 +185,15 @@ def _render_toml(cfg: UserConfig) -> str:
     lines.append("")
     lines.append("[paths]")
     if paths.anno1800_save_dir is None:
-        lines.append('# anno1800_save_dir = "C:\\\\Users\\\\<you>\\\\Documents\\\\Anno 1800\\\\accounts\\\\<id>\\\\savegame"')
+        lines.append(
+            '# anno1800_save_dir = "C:\\\\Users\\\\<you>\\\\Documents\\\\Anno 1800\\\\accounts\\\\<id>\\\\savegame"'
+        )
     else:
         lines.append(f'anno1800_save_dir = "{_quote(paths.anno1800_save_dir)}"')
     if paths.anno117_save_dir is None:
-        lines.append('# anno117_save_dir = "C:\\\\Users\\\\<you>\\\\Documents\\\\Anno 117 - Pax Romana\\\\accounts\\\\<id>\\\\savegame"')
+        lines.append(
+            '# anno117_save_dir = "C:\\\\Users\\\\<you>\\\\Documents\\\\Anno 117 - Pax Romana\\\\accounts\\\\<id>\\\\savegame"'
+        )
     else:
         lines.append(f'anno117_save_dir = "{_quote(paths.anno117_save_dir)}"')
     return "\n".join(lines) + "\n"

--- a/src/anno_save_analyzer/config.py
+++ b/src/anno_save_analyzer/config.py
@@ -12,6 +12,10 @@
     chart_window = "120m"
     recent_window_minutes = 120
 
+    [paths]
+    anno1800_save_dir = "C:\\Users\\<you>\\Documents\\Anno 1800\\accounts\\<id>\\savegame"
+    anno117_save_dir = "C:\\Users\\<you>\\Documents\\Anno 117 - Pax Romana\\accounts\\<id>\\savegame"
+
 - 破損 TOML / 未知キー / ファイル無しは default に倒し stderr に warning．
   CLI 起動を止めない (書記長が混乱する)．
 - 環境変数 ``ANNO_SAVE_ANALYZER_CONFIG`` で完全 override (test / 1 回限りの
@@ -70,10 +74,22 @@ class UiConfig(BaseModel):
     model_config = {"frozen": True, "extra": "ignore"}
 
 
+class PathsConfig(BaseModel):
+    """save ディレクトリの永続化．installed (``uv tool install``) 環境では
+    repo root の ``.env`` が読めないため，XDG config に置く．
+    """
+
+    anno1800_save_dir: str | None = None
+    anno117_save_dir: str | None = None
+
+    model_config = {"frozen": True, "extra": "ignore"}
+
+
 class UserConfig(BaseModel):
     """書記長のユーザー設定一式．拡張は sub-section (``[section]``) 追加で．"""
 
     ui: UiConfig = Field(default_factory=UiConfig)
+    paths: PathsConfig = Field(default_factory=PathsConfig)
 
     model_config = {"frozen": True, "extra": "ignore"}
 
@@ -153,7 +169,7 @@ def save_config(cfg: UserConfig, path: Path | None = None) -> Path | None:
 
 
 def _render_toml(cfg: UserConfig) -> str:
-    """UiConfig を TOML 文字列にシリアライズ．手書き (tomli-w を増やさない)．"""
+    """UserConfig を TOML 文字列にシリアライズ．手書き (tomli-w を増やさない)．"""
     ui = cfg.ui
     lines: list[str] = ["[ui]"]
     lines.append(f'locale = "{_quote(ui.locale)}"')
@@ -164,6 +180,18 @@ def _render_toml(cfg: UserConfig) -> str:
         lines.append("# recent_window_minutes = 60   # コメントアウト = 全期間")
     else:
         lines.append(f"recent_window_minutes = {ui.recent_window_minutes}")
+
+    paths = cfg.paths
+    lines.append("")
+    lines.append("[paths]")
+    if paths.anno1800_save_dir is None:
+        lines.append('# anno1800_save_dir = "C:\\\\Users\\\\<you>\\\\Documents\\\\Anno 1800\\\\accounts\\\\<id>\\\\savegame"')
+    else:
+        lines.append(f'anno1800_save_dir = "{_quote(paths.anno1800_save_dir)}"')
+    if paths.anno117_save_dir is None:
+        lines.append('# anno117_save_dir = "C:\\\\Users\\\\<you>\\\\Documents\\\\Anno 117 - Pax Romana\\\\accounts\\\\<id>\\\\savegame"')
+    else:
+        lines.append(f'anno117_save_dir = "{_quote(paths.anno117_save_dir)}"')
     return "\n".join(lines) + "\n"
 
 

--- a/src/anno_save_analyzer/gui/__main__.py
+++ b/src/anno_save_analyzer/gui/__main__.py
@@ -14,6 +14,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from anno_save_analyzer.latest_save import resolve_save
 from anno_save_analyzer.trade.models import GameTitle
 from anno_save_analyzer.tui.state import load_state
 
@@ -28,7 +29,16 @@ def _run_qt_event_loop(app) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("save", type=Path, help="Anno save file (.a7s / .a8s)")
+    parser.add_argument(
+        "save",
+        type=Path,
+        nargs="?",
+        default=None,
+        help=(
+            "Anno save file (.a7s / .a8s). Omit to auto-select the newest save "
+            "from config.toml ([paths] anno1800_save_dir / anno117_save_dir)."
+        ),
+    )
     parser.add_argument(
         "--title",
         choices=[t.value for t in GameTitle],
@@ -38,12 +48,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--locale", default="en", help="UI locale (en / ja)")
     args = parser.parse_args(argv)
 
-    if not args.save.is_file():
-        print(f"ERROR: save file not found: {args.save}", file=sys.stderr)
+    title = GameTitle(args.title)
+    resolved = resolve_save(args.save, title)
+    if resolved is None:
+        field = "anno1800_save_dir" if title is GameTitle.ANNO_1800 else "anno117_save_dir"
+        print(
+            f"ERROR: save not specified and [paths] {field} is unset or empty. "
+            "Pass the save path or set it in your config.toml.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.save is None:
+        print(f"Auto-selected latest save: {resolved}", file=sys.stderr)
+    if not resolved.is_file():
+        print(f"ERROR: save file not found: {resolved}", file=sys.stderr)
         return 2
 
-    title = GameTitle(args.title)
-    state = load_state(args.save, title=title, locale=args.locale)
+    state = load_state(resolved, title=title, locale=args.locale)
 
     from PySide6.QtGui import QFont
     from PySide6.QtWidgets import QApplication

--- a/src/anno_save_analyzer/gui/__main__.py
+++ b/src/anno_save_analyzer/gui/__main__.py
@@ -53,8 +53,10 @@ def main(argv: list[str] | None = None) -> int:
     if resolved is None:
         field = "anno1800_save_dir" if title is GameTitle.ANNO_1800 else "anno117_save_dir"
         print(
-            f"ERROR: save not specified and [paths] {field} is unset or empty. "
-            "Pass the save path or set it in your config.toml.",
+            f"ERROR: could not auto-select a save from [paths] {field}. "
+            "The setting may be unset, the configured directory may not exist, "
+            "or it may contain no matching .a7s/.a8s files. "
+            "Pass the save path or fix your config.toml.",
             file=sys.stderr,
         )
         return 2

--- a/src/anno_save_analyzer/latest_save.py
+++ b/src/anno_save_analyzer/latest_save.py
@@ -1,0 +1,77 @@
+"""``config.toml`` ベースの save ディレクトリ解決 & 最新 save 自動選択．
+
+書記長要望 (2026-04-25):
+
+- ``~/.config/anno-save-analyzer/config.toml`` (Win: ``%APPDATA%/...``) の
+  ``[paths]`` section で ``anno1800_save_dir`` / ``anno117_save_dir`` を指定
+- CLI / GUI 起動で ``save`` 引数を省略した時は ``--title`` に対応する dir の
+  最新 mtime の ``.a7s`` (Anno 1800) / ``.a8s`` (Anno 117) を自動選択
+
+XDG 準拠の user config に置くので ``uv tool install`` でも有効．repo root
+``.env`` 方式は CWD 依存で installed 環境で破綻するため採用しない．
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import UserConfig, load_config
+from .trade.models import GameTitle
+
+_SUFFIX_BY_TITLE: dict[GameTitle, str] = {
+    GameTitle.ANNO_1800: ".a7s",
+    GameTitle.ANNO_117: ".a8s",
+}
+
+
+def _save_dir_field(cfg: UserConfig, title: GameTitle) -> str | None:
+    if title is GameTitle.ANNO_1800:
+        return cfg.paths.anno1800_save_dir
+    if title is GameTitle.ANNO_117:
+        return cfg.paths.anno117_save_dir
+    return None  # pragma: no cover - GameTitle 増えた時の保険
+
+
+def save_dir_for(title: GameTitle, cfg: UserConfig | None = None) -> Path | None:
+    """指定 title の save ディレクトリを config から取得．
+
+    未設定 or ディレクトリ非存在なら ``None`` を返す．``cfg`` を渡さなければ
+    ``load_config()`` が呼ばれるが，呼び出し側が既に config を持ってるなら
+    渡したほうが I/O 1 回節約できる．
+    """
+    cfg = cfg or load_config()
+    raw = _save_dir_field(cfg, title)
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    return path if path.is_dir() else None
+
+
+def latest_save(title: GameTitle, cfg: UserConfig | None = None) -> Path | None:
+    """``save_dir_for(title)`` 配下から最新 mtime の save ファイルを返す．
+
+    Anno 1800 → ``.a7s`` / Anno 117 → ``.a8s``．該当 dir が無い or ファイル
+    0 件なら ``None``．
+    """
+    dir_ = save_dir_for(title, cfg=cfg)
+    if dir_ is None:
+        return None
+    suffix = _SUFFIX_BY_TITLE[title]
+    saves = list(dir_.glob(f"*{suffix}"))
+    if not saves:
+        return None
+    return max(saves, key=lambda p: p.stat().st_mtime)
+
+
+def resolve_save(
+    save: Path | None, title: GameTitle, cfg: UserConfig | None = None
+) -> Path | None:
+    """CLI 引数 ``save`` の解決ロジック．
+
+    - ``save`` 明示指定 → そのまま
+    - 未指定 → config の save dir から最新 save を探す
+    - 見つからない → ``None`` (呼び出し側でエラー処理)
+    """
+    if save is not None:
+        return save
+    return latest_save(title, cfg=cfg)

--- a/src/anno_save_analyzer/latest_save.py
+++ b/src/anno_save_analyzer/latest_save.py
@@ -52,15 +52,26 @@ def latest_save(title: GameTitle, cfg: UserConfig | None = None) -> Path | None:
 
     Anno 1800 → ``.a7s`` / Anno 117 → ``.a8s``．該当 dir が無い or ファイル
     0 件なら ``None``．
+
+    Anno は autosave 中に旧 save を delete → rename するため ``glob`` と
+    ``stat`` の間でファイルが消える race がある．lazy iteration + 個別
+    ``FileNotFoundError`` 握り潰しで再現可能性を最小化する．
     """
     dir_ = save_dir_for(title, cfg=cfg)
     if dir_ is None:
         return None
     suffix = _SUFFIX_BY_TITLE[title]
-    saves = list(dir_.glob(f"*{suffix}"))
-    if not saves:
-        return None
-    return max(saves, key=lambda p: p.stat().st_mtime)
+    latest: Path | None = None
+    latest_mtime: float | None = None
+    for path in dir_.glob(f"*{suffix}"):
+        try:
+            mtime = path.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if latest_mtime is None or mtime > latest_mtime:
+            latest = path
+            latest_mtime = mtime
+    return latest
 
 
 def resolve_save(save: Path | None, title: GameTitle, cfg: UserConfig | None = None) -> Path | None:

--- a/src/anno_save_analyzer/latest_save.py
+++ b/src/anno_save_analyzer/latest_save.py
@@ -63,9 +63,7 @@ def latest_save(title: GameTitle, cfg: UserConfig | None = None) -> Path | None:
     return max(saves, key=lambda p: p.stat().st_mtime)
 
 
-def resolve_save(
-    save: Path | None, title: GameTitle, cfg: UserConfig | None = None
-) -> Path | None:
+def resolve_save(save: Path | None, title: GameTitle, cfg: UserConfig | None = None) -> Path | None:
     """CLI 引数 ``save`` の解決ロジック．
 
     - ``save`` 明示指定 → そのまま

--- a/tests/cli/test_state.py
+++ b/tests/cli/test_state.py
@@ -121,7 +121,7 @@ def test_state_command_compact_indent(
 
 
 def test_state_command_missing_save_fails(runner: CliRunner, tmp_path: Path) -> None:
-    """存在しない save path は click の ``exists=True`` で落ちる．"""
+    """明示指定された save path が存在しない場合は exit 2 + 明確なエラー．"""
     out = tmp_path / "state.json"
     result = runner.invoke(
         app,
@@ -135,4 +135,44 @@ def test_state_command_missing_save_fails(runner: CliRunner, tmp_path: Path) -> 
         ],
     )
     assert result.exit_code != 0
+    assert "save file not found" in result.output
     assert not out.exists()
+
+
+def test_state_command_save_omitted_no_config_fails(
+    runner: CliRunner, tmp_path: Path, monkeypatch
+) -> None:
+    """save 省略 + config の ``[paths]`` 未設定 → exit 2 + ガイドメッセージ．"""
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text("[ui]\nlocale = 'en'\n", encoding="utf-8")
+    monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+    out = tmp_path / "state.json"
+    result = runner.invoke(
+        app, ["state", "--title", "anno117", "--out", str(out)]
+    )
+    assert result.exit_code == 2
+    assert "anno117_save_dir" in result.output
+    assert "config.toml" in result.output
+
+
+def test_state_command_save_omitted_picks_latest_from_config(
+    runner: CliRunner, synthetic_save: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """save 省略 + ``[paths] anno117_save_dir`` 設定 → 最新 ``.a8s`` を自動選択．"""
+    save_dir = tmp_path / "saves"
+    save_dir.mkdir()
+    target = save_dir / "auto.a8s"
+    target.write_bytes(synthetic_save.read_bytes())
+
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text(
+        f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8"
+    )
+    monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+
+    out = tmp_path / "state.json"
+    result = runner.invoke(app, ["state", "--title", "anno117", "--out", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "Auto-selected latest save" in result.output
+    assert "auto.a8s" in result.output
+    assert out.exists()

--- a/tests/cli/test_state.py
+++ b/tests/cli/test_state.py
@@ -147,9 +147,7 @@ def test_state_command_save_omitted_no_config_fails(
     cfg.write_text("[ui]\nlocale = 'en'\n", encoding="utf-8")
     monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
     out = tmp_path / "state.json"
-    result = runner.invoke(
-        app, ["state", "--title", "anno117", "--out", str(out)]
-    )
+    result = runner.invoke(app, ["state", "--title", "anno117", "--out", str(out)])
     assert result.exit_code == 2
     assert "anno117_save_dir" in result.output
     assert "config.toml" in result.output
@@ -165,9 +163,7 @@ def test_state_command_save_omitted_picks_latest_from_config(
     target.write_bytes(synthetic_save.read_bytes())
 
     cfg = tmp_path / "cfg.toml"
-    cfg.write_text(
-        f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8"
-    )
+    cfg.write_text(f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8")
     monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
 
     out = tmp_path / "state.json"

--- a/tests/cli/test_tui_cmd.py
+++ b/tests/cli/test_tui_cmd.py
@@ -173,6 +173,45 @@ class TestTuiCommand:
         assert result.exit_code == 0
         assert captured["state_locale"] == "en"
 
+    def test_tui_save_omitted_without_title_fails(self, tmp_path: Path, monkeypatch) -> None:
+        """save 省略 + ``--title`` 未指定 → exit 2 + ``--title`` 要求メッセージ．"""
+        cfg = tmp_path / "cfg.toml"
+        cfg.write_text("", encoding="utf-8")
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+        result = runner.invoke(app, ["tui"])
+        assert result.exit_code == 2
+        assert "--title" in result.output
+
+    def test_tui_save_omitted_no_config_path_fails(self, tmp_path: Path, monkeypatch) -> None:
+        """save 省略 + ``--title`` あり + config に paths 未設定 → exit 2 + ガイド．"""
+        cfg = tmp_path / "cfg.toml"
+        cfg.write_text("[ui]\n", encoding="utf-8")
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+        result = runner.invoke(app, ["tui", "--title", "anno1800"])
+        assert result.exit_code == 2
+        assert "anno1800_save_dir" in result.output
+
+    def test_tui_save_omitted_picks_latest_from_config(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """save 省略 + config 設定済 → 最新 save を自動選択して TUI 起動．"""
+        save_dir = tmp_path / "saves"
+        save_dir.mkdir()
+        save = save_dir / "auto.a8s"
+        save.write_bytes(_make_save(tmp_path).read_bytes())
+
+        cfg = tmp_path / "cfg.toml"
+        cfg.write_text(
+            f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8"
+        )
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+
+        with patch("anno_save_analyzer.tui.TradeApp.run"):
+            result = runner.invoke(app, ["tui", "--title", "anno117"])
+        assert result.exit_code == 0, result.output
+        assert "Auto-selected latest save" in result.output
+        assert "auto.a8s" in result.output
+
     def test_tui_warns_on_unknown_theme_in_config(self, tmp_path: Path, monkeypatch) -> None:
         """破損 theme 値は default にフォールバックし warning を出す．"""
         cfg_path = tmp_path / "cfg.toml"

--- a/tests/cli/test_tui_cmd.py
+++ b/tests/cli/test_tui_cmd.py
@@ -191,9 +191,7 @@ class TestTuiCommand:
         assert result.exit_code == 2
         assert "anno1800_save_dir" in result.output
 
-    def test_tui_save_omitted_picks_latest_from_config(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_tui_save_omitted_picks_latest_from_config(self, tmp_path: Path, monkeypatch) -> None:
         """save 省略 + config 設定済 → 最新 save を自動選択して TUI 起動．"""
         save_dir = tmp_path / "saves"
         save_dir.mkdir()
@@ -201,9 +199,7 @@ class TestTuiCommand:
         save.write_bytes(_make_save(tmp_path).read_bytes())
 
         cfg = tmp_path / "cfg.toml"
-        cfg.write_text(
-            f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8"
-        )
+        cfg.write_text(f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8")
         monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
 
         with patch("anno_save_analyzer.tui.TradeApp.run"):

--- a/tests/gui/test_main_entry.py
+++ b/tests/gui/test_main_entry.py
@@ -41,9 +41,7 @@ def test_gui_main_explicit_missing_path_returns_2(tmp_path: Path, capsys) -> Non
     assert "save file not found" in capsys.readouterr().err
 
 
-def test_gui_main_save_omitted_picks_latest(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_gui_main_save_omitted_picks_latest(tmp_path: Path, monkeypatch, capsys) -> None:
     """save 省略 + config 設定済 → 最新 save を選び GUI を起動．
 
     QApplication / BalanceMainWindow / event loop すべて mock するため
@@ -57,9 +55,7 @@ def test_gui_main_save_omitted_picks_latest(
     save.write_bytes(_synth_save(tmp_path).read_bytes())
 
     cfg = tmp_path / "cfg.toml"
-    cfg.write_text(
-        f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8"
-    )
+    cfg.write_text(f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8")
     monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
 
     with (

--- a/tests/gui/test_main_entry.py
+++ b/tests/gui/test_main_entry.py
@@ -1,0 +1,78 @@
+"""``anno-save-analyzer-gui`` entry の save 解決テスト．
+
+実 Qt event loop は起動せず，``QApplication`` / ``main_window``
+を mock して main() の早期 return パスだけを叩く．
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from anno_save_analyzer.gui import __main__ as gui_main
+
+
+def _synth_save(tmp_path: Path) -> Path:
+    from tests.trade.conftest import make_inner_filedb, wrap_as_outer
+
+    inner = make_inner_filedb({"route": [(7, 100, 5, 0)]})
+    save = tmp_path / "fake.a8s"
+    save.write_bytes(wrap_as_outer([inner]))
+    return save
+
+
+def test_gui_main_save_omitted_no_config(tmp_path: Path, monkeypatch, capsys) -> None:
+    """save 省略 + config に paths 未設定 → exit 2 + ガイドメッセージ．"""
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text("[ui]\n", encoding="utf-8")
+    monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+
+    rc = gui_main.main(["--title", "anno1800"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "anno1800_save_dir" in err
+    assert "config.toml" in err
+
+
+def test_gui_main_explicit_missing_path_returns_2(tmp_path: Path, capsys) -> None:
+    """明示指定された path が存在しない → exit 2 + ``save file not found``．"""
+    rc = gui_main.main([str(tmp_path / "nope.a7s"), "--title", "anno1800"])
+    assert rc == 2
+    assert "save file not found" in capsys.readouterr().err
+
+
+def test_gui_main_save_omitted_picks_latest(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """save 省略 + config 設定済 → 最新 save を選び GUI を起動．
+
+    QApplication / BalanceMainWindow / event loop すべて mock するため
+    実 Qt 環境を要さず default CI でも実行できる．``@pytest.mark.gui`` は
+    pytest-qt を伴う本物の widget 試験のためのマーカで，このような
+    smoke test には適用しない．
+    """
+    save_dir = tmp_path / "saves"
+    save_dir.mkdir()
+    save = save_dir / "auto.a8s"
+    save.write_bytes(_synth_save(tmp_path).read_bytes())
+
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text(
+        f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8"
+    )
+    monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
+
+    with (
+        patch.object(gui_main, "load_state", return_value=object()),
+        patch("PySide6.QtWidgets.QApplication") as qapp_cls,
+        patch("anno_save_analyzer.gui.main_window.BalanceMainWindow"),
+        patch.object(gui_main, "_run_qt_event_loop", return_value=0) as loop_mock,
+    ):
+        qapp_cls.instance.return_value = None
+        rc = gui_main.main(["--title", "anno117"])
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "Auto-selected latest save" in err
+    assert "auto.a8s" in err
+    loop_mock.assert_called_once()

--- a/tests/gui/test_main_entry.py
+++ b/tests/gui/test_main_entry.py
@@ -6,8 +6,9 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from anno_save_analyzer.gui import __main__ as gui_main
 
@@ -44,10 +45,9 @@ def test_gui_main_explicit_missing_path_returns_2(tmp_path: Path, capsys) -> Non
 def test_gui_main_save_omitted_picks_latest(tmp_path: Path, monkeypatch, capsys) -> None:
     """save 省略 + config 設定済 → 最新 save を選び GUI を起動．
 
-    QApplication / BalanceMainWindow / event loop すべて mock するため
-    実 Qt 環境を要さず default CI でも実行できる．``@pytest.mark.gui`` は
-    pytest-qt を伴う本物の widget 試験のためのマーカで，このような
-    smoke test には適用しない．
+    PySide6 が **install されてない CI 環境でも動かす** ため，``sys.modules``
+    に MagicMock を inject して ``from PySide6.QtGui import QFont`` 等の
+    遅延 import を吸収する．書記長 GUI extra (``[gui]``) は dev group のみ．
     """
     save_dir = tmp_path / "saves"
     save_dir.mkdir()
@@ -58,13 +58,24 @@ def test_gui_main_save_omitted_picks_latest(tmp_path: Path, monkeypatch, capsys)
     cfg.write_text(f'[paths]\nanno117_save_dir = "{save_dir}"\n', encoding="utf-8")
     monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg))
 
+    fake_pyside6 = MagicMock()
+    fake_qtgui = MagicMock()
+    fake_qtwidgets = MagicMock()
+    fake_qtwidgets.QApplication.instance.return_value = None
+    fake_main_window = MagicMock()
+
+    sys_modules_patch = {
+        "PySide6": fake_pyside6,
+        "PySide6.QtGui": fake_qtgui,
+        "PySide6.QtWidgets": fake_qtwidgets,
+        "anno_save_analyzer.gui.main_window": fake_main_window,
+    }
+
     with (
+        patch.dict(sys.modules, sys_modules_patch),
         patch.object(gui_main, "load_state", return_value=object()),
-        patch("PySide6.QtWidgets.QApplication") as qapp_cls,
-        patch("anno_save_analyzer.gui.main_window.BalanceMainWindow"),
         patch.object(gui_main, "_run_qt_event_loop", return_value=0) as loop_mock,
     ):
-        qapp_cls.instance.return_value = None
         rc = gui_main.main(["--title", "anno117"])
 
     assert rc == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,8 +179,7 @@ class TestPathsConfig:
         save_config(cfg, path)
         loaded = load_config(path)
         assert (
-            loaded.paths.anno1800_save_dir
-            == r"C:\Users\u\Documents\Anno 1800\accounts\1\savegame"
+            loaded.paths.anno1800_save_dir == r"C:\Users\u\Documents\Anno 1800\accounts\1\savegame"
         )
         assert loaded.paths.anno117_save_dir == "/home/u/.steam/anno117/savegame"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ import pytest
 
 from anno_save_analyzer.config import (
     _ENV_OVERRIDE,
+    PathsConfig,
     UiConfig,
     UserConfig,
     chart_window_from_token,
@@ -164,3 +165,42 @@ class TestSaveConfig:
         save_config(UserConfig(ui=UiConfig(locale='weird"locale\\x', theme="default")), path)
         loaded = load_config(path)
         assert loaded.ui.locale == 'weird"locale\\x'
+
+
+class TestPathsConfig:
+    def test_round_trip_with_save_dirs(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        cfg = UserConfig(
+            paths=PathsConfig(
+                anno1800_save_dir=r"C:\Users\u\Documents\Anno 1800\accounts\1\savegame",
+                anno117_save_dir="/home/u/.steam/anno117/savegame",
+            )
+        )
+        save_config(cfg, path)
+        loaded = load_config(path)
+        assert (
+            loaded.paths.anno1800_save_dir
+            == r"C:\Users\u\Documents\Anno 1800\accounts\1\savegame"
+        )
+        assert loaded.paths.anno117_save_dir == "/home/u/.steam/anno117/savegame"
+
+    def test_unset_paths_are_commented_out(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.toml"
+        save_config(UserConfig(), path)
+        text = path.read_text(encoding="utf-8")
+        assert "[paths]" in text
+        assert "# anno1800_save_dir" in text
+        assert "# anno117_save_dir" in text
+
+    def test_partial_paths_persist(self, tmp_path: Path) -> None:
+        """1800 だけ設定した場合，117 はコメントアウトのまま保存される．"""
+        path = tmp_path / "cfg.toml"
+        save_config(
+            UserConfig(paths=PathsConfig(anno1800_save_dir="/saves/1800")),
+            path,
+        )
+        loaded = load_config(path)
+        assert loaded.paths.anno1800_save_dir == "/saves/1800"
+        assert loaded.paths.anno117_save_dir is None
+        text = path.read_text(encoding="utf-8")
+        assert "# anno117_save_dir" in text

--- a/tests/test_latest_save.py
+++ b/tests/test_latest_save.py
@@ -6,7 +6,7 @@ env vars ではなく ``UserConfig`` を組み立てて渡す方針．installed 
 
 from __future__ import annotations
 
-import time
+import os
 from pathlib import Path
 
 import pytest
@@ -18,6 +18,13 @@ from anno_save_analyzer.trade.models import GameTitle
 
 def _cfg(**paths: str | None) -> UserConfig:
     return UserConfig(paths=PathsConfig(**paths))
+
+
+def _set_mtime(path: Path, when: float) -> None:
+    """``os.utime`` で mtime を明示的に固定．粗 FS ts (HFS+/exFAT) でも
+    順序が決定論的になる．``time.sleep`` 依存を排除．
+    """
+    os.utime(path, (when, when))
 
 
 class TestSaveDirFor:
@@ -59,8 +66,9 @@ class TestLatestSave:
         old = tmp_path / "old.a7s"
         new = tmp_path / "new.a7s"
         old.write_bytes(b"x")
-        time.sleep(0.05)
         new.write_bytes(b"y")
+        _set_mtime(old, 1_000_000.0)
+        _set_mtime(new, 2_000_000.0)
         assert latest_save(GameTitle.ANNO_1800, cfg=cfg) == new
 
     def test_ignores_other_extensions(self, tmp_path: Path) -> None:
@@ -83,6 +91,29 @@ class TestLatestSave:
         cfg = _cfg()
         assert latest_save(GameTitle.ANNO_1800, cfg=cfg) is None
 
+    def test_skips_files_that_disappear_between_glob_and_stat(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """autosave 中に旧 save が delete → rename される race を吸収する．"""
+        cfg = _cfg(anno1800_save_dir=str(tmp_path))
+        survivor = tmp_path / "survivor.a7s"
+        ghost = tmp_path / "ghost.a7s"
+        survivor.write_bytes(b"x")
+        ghost.write_bytes(b"y")
+        _set_mtime(survivor, 1_000_000.0)
+        _set_mtime(ghost, 2_000_000.0)  # 本来こちらが選ばれるはず
+
+        original_stat = Path.stat
+
+        def stat_with_ghost_gone(self: Path, *args, **kwargs):
+            if self == ghost:
+                raise FileNotFoundError(f"{self} disappeared")
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", stat_with_ghost_gone)
+        # ghost は stat 失敗するので survivor が返る
+        assert latest_save(GameTitle.ANNO_1800, cfg=cfg) == survivor
+
 
 class TestResolveSave:
     def test_explicit_path_returned_as_is(self, tmp_path: Path) -> None:
@@ -92,10 +123,13 @@ class TestResolveSave:
 
     def test_none_falls_back_to_latest(self, tmp_path: Path) -> None:
         cfg = _cfg(anno1800_save_dir=str(tmp_path))
-        (tmp_path / "one.a7s").write_bytes(b"x")
-        time.sleep(0.05)
-        (tmp_path / "two.a7s").write_bytes(b"y")
-        assert resolve_save(None, GameTitle.ANNO_1800, cfg=cfg) == tmp_path / "two.a7s"
+        one = tmp_path / "one.a7s"
+        two = tmp_path / "two.a7s"
+        one.write_bytes(b"x")
+        two.write_bytes(b"y")
+        _set_mtime(one, 1_000_000.0)
+        _set_mtime(two, 2_000_000.0)
+        assert resolve_save(None, GameTitle.ANNO_1800, cfg=cfg) == two
 
     def test_none_returns_none_when_nothing_found(self) -> None:
         assert resolve_save(None, GameTitle.ANNO_1800, cfg=_cfg()) is None

--- a/tests/test_latest_save.py
+++ b/tests/test_latest_save.py
@@ -1,0 +1,119 @@
+"""``latest_save`` の save 解決 / 最新選択のテスト．
+
+env vars ではなく ``UserConfig`` を組み立てて渡す方針．installed user の
+``~/.config/anno-save-analyzer/config.toml`` ベースの解決を検証する．
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from anno_save_analyzer.config import PathsConfig, UserConfig
+from anno_save_analyzer.latest_save import latest_save, resolve_save, save_dir_for
+from anno_save_analyzer.trade.models import GameTitle
+
+
+def _cfg(**paths: str | None) -> UserConfig:
+    return UserConfig(paths=PathsConfig(**paths))
+
+
+class TestSaveDirFor:
+    def test_returns_path_when_config_set(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno1800_save_dir=str(tmp_path))
+        assert save_dir_for(GameTitle.ANNO_1800, cfg=cfg) == tmp_path
+
+    def test_returns_none_when_config_unset(self) -> None:
+        cfg = _cfg()
+        assert save_dir_for(GameTitle.ANNO_1800, cfg=cfg) is None
+
+    def test_returns_none_when_config_empty_string(self) -> None:
+        cfg = _cfg(anno1800_save_dir="")
+        assert save_dir_for(GameTitle.ANNO_1800, cfg=cfg) is None
+
+    def test_returns_none_when_path_missing(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno1800_save_dir=str(tmp_path / "does-not-exist"))
+        assert save_dir_for(GameTitle.ANNO_1800, cfg=cfg) is None
+
+    def test_anno117_uses_separate_field(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno117_save_dir=str(tmp_path))
+        assert save_dir_for(GameTitle.ANNO_117, cfg=cfg) == tmp_path
+        assert save_dir_for(GameTitle.ANNO_1800, cfg=cfg) is None
+
+    def test_loads_default_config_when_cfg_omitted(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # ANNO_SAVE_ANALYZER_CONFIG で config.toml を差し替え，呼び出し側が
+        # ``cfg`` を渡さなくても load_config 経由で読まれることを確認．
+        cfg_path = tmp_path / "config.toml"
+        save_dir = tmp_path / "saves"
+        save_dir.mkdir()
+        cfg_path.write_text(
+            f'[paths]\nanno1800_save_dir = "{save_dir}"\n', encoding="utf-8"
+        )
+        monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
+        assert save_dir_for(GameTitle.ANNO_1800) == save_dir
+
+
+class TestLatestSave:
+    def test_returns_newest_mtime_a7s(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno1800_save_dir=str(tmp_path))
+        old = tmp_path / "old.a7s"
+        new = tmp_path / "new.a7s"
+        old.write_bytes(b"x")
+        time.sleep(0.05)
+        new.write_bytes(b"y")
+        assert latest_save(GameTitle.ANNO_1800, cfg=cfg) == new
+
+    def test_ignores_other_extensions(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno1800_save_dir=str(tmp_path))
+        (tmp_path / "decoy.txt").write_bytes(b"x")
+        (tmp_path / "only.a7s").write_bytes(b"y")
+        assert latest_save(GameTitle.ANNO_1800, cfg=cfg) == tmp_path / "only.a7s"
+
+    def test_a8s_for_anno117(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno117_save_dir=str(tmp_path))
+        (tmp_path / "wrong.a7s").write_bytes(b"x")
+        (tmp_path / "right.a8s").write_bytes(b"y")
+        assert latest_save(GameTitle.ANNO_117, cfg=cfg) == tmp_path / "right.a8s"
+
+    def test_returns_none_when_no_saves(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno1800_save_dir=str(tmp_path))
+        assert latest_save(GameTitle.ANNO_1800, cfg=cfg) is None
+
+    def test_returns_none_when_dir_missing(self) -> None:
+        cfg = _cfg()
+        assert latest_save(GameTitle.ANNO_1800, cfg=cfg) is None
+
+
+class TestResolveSave:
+    def test_explicit_path_returned_as_is(self, tmp_path: Path) -> None:
+        p = tmp_path / "mysave.a7s"
+        p.write_bytes(b"x")
+        assert resolve_save(p, GameTitle.ANNO_1800, cfg=_cfg()) == p
+
+    def test_none_falls_back_to_latest(self, tmp_path: Path) -> None:
+        cfg = _cfg(anno1800_save_dir=str(tmp_path))
+        (tmp_path / "one.a7s").write_bytes(b"x")
+        time.sleep(0.05)
+        (tmp_path / "two.a7s").write_bytes(b"y")
+        assert resolve_save(None, GameTitle.ANNO_1800, cfg=cfg) == tmp_path / "two.a7s"
+
+    def test_none_returns_none_when_nothing_found(self) -> None:
+        assert resolve_save(None, GameTitle.ANNO_1800, cfg=_cfg()) is None
+
+
+@pytest.mark.parametrize(
+    ("title", "field"),
+    [
+        (GameTitle.ANNO_1800, "anno1800_save_dir"),
+        (GameTitle.ANNO_117, "anno117_save_dir"),
+    ],
+)
+def test_save_dir_for_uses_title_specific_field(
+    tmp_path: Path, title: GameTitle, field: str
+) -> None:
+    cfg = _cfg(**{field: str(tmp_path)})
+    assert save_dir_for(title, cfg=cfg) == tmp_path

--- a/tests/test_latest_save.py
+++ b/tests/test_latest_save.py
@@ -42,17 +42,13 @@ class TestSaveDirFor:
         assert save_dir_for(GameTitle.ANNO_117, cfg=cfg) == tmp_path
         assert save_dir_for(GameTitle.ANNO_1800, cfg=cfg) is None
 
-    def test_loads_default_config_when_cfg_omitted(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_loads_default_config_when_cfg_omitted(self, tmp_path: Path, monkeypatch) -> None:
         # ANNO_SAVE_ANALYZER_CONFIG で config.toml を差し替え，呼び出し側が
         # ``cfg`` を渡さなくても load_config 経由で読まれることを確認．
         cfg_path = tmp_path / "config.toml"
         save_dir = tmp_path / "saves"
         save_dir.mkdir()
-        cfg_path.write_text(
-            f'[paths]\nanno1800_save_dir = "{save_dir}"\n', encoding="utf-8"
-        )
+        cfg_path.write_text(f'[paths]\nanno1800_save_dir = "{save_dir}"\n', encoding="utf-8")
         monkeypatch.setenv("ANNO_SAVE_ANALYZER_CONFIG", str(cfg_path))
         assert save_dir_for(GameTitle.ANNO_1800) == save_dir
 


### PR DESCRIPTION
## Summary

- Adds a `[paths]` section to `~/.config/anno-save-analyzer/config.toml` (Win: `%APPDATA%\anno-save-analyzer\config.toml`) for `anno1800_save_dir` / `anno117_save_dir`.
- `anno-save-analyzer tui` / `state` / `anno-save-analyzer-gui` now treat the save argument as optional — when omitted, they pick the **most recently modified** `.a7s` / `.a8s` matching `--title` from that directory.
- Explicit save path always wins over the config lookup.
- Drops `python-dotenv` from base deps; deletes `.env.example` and `env_config.py`.

## Why config.toml instead of .env

The earlier `.env` proposal only worked when the CLI was launched from the repo root, which breaks the standard installed paths (`uv tool install`, `pipx`). The XDG `config.toml` already exists for `[ui]` settings (locale / theme / chart window) — extending it with `[paths]` keeps everything in one CWD-independent file.

## Schema

```toml
[paths]
anno1800_save_dir = "C:\\Users\\<you>\\Documents\\Anno 1800\\accounts\\<id>\\savegame"
anno117_save_dir = "/mnt/c/Users/<you>/Documents/Anno 117 - Pax Romana/accounts/<id>/savegame"
```

## Test plan

- [x] `tests/test_latest_save.py` — 16 tests, `latest_save.py` 100% covered
- [x] `tests/test_config.py` — 3 new tests for `[paths]` round-trip / commented-out fallback / partial set
- [x] Full suite: 703 passed, `fail_under = 90` met
- [x] `ruff check` clean
- [x] CLI / GUI imports verified

## Docs

Sphinx Quickstart updated in #94 with the new mechanism + per-OS config-file location table (EN + JA).