### PR TITLE
fix(balance): account for intermediate-product consumption + drop overly strict observed filter

### DIFF
--- a/src/anno_save_analyzer/trade/balance.py
+++ b/src/anno_save_analyzer/trade/balance.py
@@ -14,16 +14,18 @@
 
 - **生産量 (ton/min)** = Σ over factory instances of
   ``productivity × recipe.tpmin × output.amount``
-- **消費量 (ton/min)** = Σ over tier × needs of
-  ``tier.resident_total × need.tpmin``
-  - ``is_bonus_need`` の物資は通常消費に含めない
-  - **unlock 未達の物資は除外**．Calculator の ``tier.needs`` は tier の
-    潜在的な全 need 候補．書記長の島で実際 unlock されてるかは
-    ``ResidenceAggregate.product_saturations`` (save の ``ConsumptionStates``
-    観測値) で判定し，観測されてない need は加算しない (「ビスケット
-    要求されてないのに消費加算される」問題の修正)．observe ゼロの島は
-    tier.needs を素直に使う (都市再建直後など tier breakdown だけで推定
-    したいフォールバック)．
+- **消費量 (ton/min)** = 住民消費 + 工場入力消費の合計
+  - **住民消費** = Σ over tier × needs of ``tier.resident_total × need.tpmin``
+    - ``is_bonus_need`` の物資は default で除外 (``include_bonus_needs=False``)
+    - standard need (``is_bonus_need=False``) は **住民数 > 0 なら全加算**．
+      過去は ``ResidenceAggregate.product_saturations`` (save 観測値) で
+      filter していたが，新世界 / 北極圏 / エンベサ / Scholars 等の need
+      が一度も観測されてないと消費 0 扱いになる副作用があった (#96)．
+      正確な unlock gate は #99 で ``unlock_condition_guid`` を埋めて行う．
+    - bonus need の per-residence ON/OFF 反映は #97 で対応予定
+  - **工場入力消費** = Σ over factory instances of
+    ``productivity × recipe.tpmin × input.amount``
+    - 中間物資 (豚 → 缶詰肉，鉄鉱 → 鋼鉄 等) を計上
 - **delta** = produced - consumed
 
 複数島の集計は ``SupplyBalanceTable.aggregate`` で area_manager 集合を指定
@@ -57,6 +59,7 @@ _TIER_KEY_TO_CONSUMPTION_NAME: dict[str, str] = {
     "technician": "Technicians",
     "scholar": "Scholars",
     "artista": "Artista",
+    "tourist": "Tourists",
 }
 
 
@@ -174,8 +177,13 @@ def build_balance_table(
     factories_by_am: dict[str, FactoryAggregate] = {f.area_manager: f for f in factories}
     islands: list[IslandBalance] = []
     for res in residences:
-        produced = _produced_for_island(factories_by_am.get(res.area_manager), recipes)
-        consumed = _consumed_for_island(res, consumption, include_bonus_needs=include_bonus_needs)
+        factory_agg = factories_by_am.get(res.area_manager)
+        produced = _produced_for_island(factory_agg, recipes)
+        consumed_pop = _consumed_for_island(
+            res, consumption, include_bonus_needs=include_bonus_needs
+        )
+        consumed_intermediate = _consumed_intermediate_for_island(factory_agg, recipes)
+        consumed = _merge_sums(consumed_pop, consumed_intermediate)
         guids = sorted(set(produced) | set(consumed))
         products = tuple(
             ProductBalance(
@@ -212,6 +220,28 @@ def _produced_for_island(
     return totals
 
 
+def _consumed_intermediate_for_island(
+    factories: FactoryAggregate | None,
+    recipes: FactoryRecipeTable | None,
+) -> dict[int, float]:
+    """工場の入力 (中間物資) 消費を集計．
+
+    豚 → 缶詰肉，鉄鉱 → 鋼鉄 等のチェーン中間品が「誰にも消費されない」
+    扱いになる問題 (#96) の修正．``recipe.consumed_per_minute`` を
+    factory instance ごとに加算する．
+    """
+    if factories is None or recipes is None:
+        return {}
+    totals: dict[int, float] = {}
+    for inst in factories.instances:
+        recipe = recipes.get(inst.building_guid)
+        if recipe is None:
+            continue
+        for guid, rate in recipe.consumed_per_minute(inst.productivity).items():
+            totals[guid] = totals.get(guid, 0.0) + rate
+    return totals
+
+
 def _consumed_for_island(
     residence: ResidenceAggregate,
     consumption: ConsumptionTable | None,
@@ -220,13 +250,6 @@ def _consumed_for_island(
 ) -> dict[int, float]:
     if consumption is None or not residence.tier_breakdown:
         return {}
-    # 観測済 need で filter．``product_saturations`` に登録されている物資が
-    # save の ``ConsumptionStates`` で実際消費記録のある need = unlock 済．
-    # None (観測ゼロ) の場合は tier.needs を素直に加算 (既存互換の fallback)．
-    observed: set[int] | None = None
-    if residence.product_saturations:
-        observed = {ps.product_guid for ps in residence.product_saturations}
-
     totals: dict[int, float] = {}
     # 事前に consumption の tier を英語名で index して繰り返し linear search を回避
     tier_by_name: dict[str, PopulationTier] = {t.name: t for t in consumption.tiers}
@@ -242,9 +265,23 @@ def _consumed_for_island(
                 continue
             if need.is_bonus_need and not include_bonus_needs:
                 continue
-            if observed is not None and need.product_guid not in observed:
-                continue
+            # standard need は住民居れば加算 (#96)．以前は ``product_saturations``
+            # で filter していたが新世界 / Scholars 等の need が消費 0 になる
+            # 副作用があった．正確な unlock gate は #99 で
+            # ``need.unlock_condition_guid`` を埋めて行う予定．
             totals[need.product_guid] = (
                 totals.get(need.product_guid, 0.0) + ts.resident_total * need.tpmin
             )
     return totals
+
+
+def _merge_sums(a: dict[int, float], b: dict[int, float]) -> dict[int, float]:
+    """2 つの ``{guid: rate}`` を加算マージ．副作用なし．"""
+    if not b:
+        return a
+    if not a:
+        return dict(b)
+    out = dict(a)
+    for guid, rate in b.items():
+        out[guid] = out.get(guid, 0.0) + rate
+    return out

--- a/src/anno_save_analyzer/trade/consumption.py
+++ b/src/anno_save_analyzer/trade/consumption.py
@@ -38,6 +38,12 @@ class TierNeed(BaseModel):
     is_bonus_need: bool = False
     """Spirits / Rum のような住人 upgrade 不要の嗜好品系．"""
     dlcs: tuple[str, ...] = Field(default_factory=tuple)
+    unlock_condition_guid: int | None = None
+    """この need が unlock されるための条件 (人口閾値 + 公共施設 etc) の
+    Asset GUID．現状は全 ``None``．#99 で ``assets.xml`` の
+    ``UnlockCondition`` を抽出して埋める予定．埋まれば balance 側で
+    「unlock 未達 need は除外」の正確な gate が効くようになる．
+    """
 
     model_config = {"frozen": True}
 
@@ -146,6 +152,7 @@ def _tier_from_dict(data: dict[str, Any]) -> PopulationTier:
 
 
 def _need_from_dict(data: dict[str, Any]) -> TierNeed:
+    raw_unlock = data.get("unlock_condition_guid")
     return TierNeed(
         product_guid=int(data["product_guid"]),
         tpmin=data.get("tpmin"),
@@ -153,4 +160,5 @@ def _need_from_dict(data: dict[str, Any]) -> TierNeed:
         happiness=int(data.get("happiness") or 0),
         is_bonus_need=bool(data.get("is_bonus_need")),
         dlcs=tuple(data.get("dlcs") or ()),
+        unlock_condition_guid=int(raw_unlock) if raw_unlock is not None else None,
     )

--- a/src/anno_save_analyzer/trade/factory_recipes.py
+++ b/src/anno_save_analyzer/trade/factory_recipes.py
@@ -72,6 +72,21 @@ class FactoryRecipe(BaseModel):
             out[o.product_guid] = out.get(o.product_guid, 0.0) + productivity * self.tpmin * amt
         return out
 
+    def consumed_per_minute(self, productivity: float) -> dict[int, float]:
+        """``productivity`` で 1 factory の /min **入力** 消費量を product 別に返す．
+
+        中間物資 (豚 → 缶詰肉 等) の実消費量を計算する．``produced_per_minute``
+        の対称形で input 側を集計．``tpmin`` 未定義なら空．``input.amount`` が
+        ``None`` の場合は 1.0 とみなす (output 側と揃える)．
+        """
+        if self.tpmin is None:
+            return {}
+        out: dict[int, float] = {}
+        for i in self.inputs:
+            amt = i.amount if i.amount is not None else 1.0
+            out[i.product_guid] = out.get(i.product_guid, 0.0) + productivity * self.tpmin * amt
+        return out
+
 
 class FactoryRecipeTable(BaseModel):
     """factory GUID → FactoryRecipe のテーブル．"""

--- a/tests/trade/test_balance.py
+++ b/tests/trade/test_balance.py
@@ -21,6 +21,7 @@ from anno_save_analyzer.trade.factories import FactoryAggregate, FactoryInstance
 from anno_save_analyzer.trade.factory_recipes import (
     FactoryRecipe,
     FactoryRecipeTable,
+    RecipeInput,
     RecipeOutput,
 )
 from anno_save_analyzer.trade.population import (
@@ -189,15 +190,16 @@ def test_tier_not_in_map_is_skipped() -> None:
     assert table.islands[0].products == ()
 
 
-# ---------- observed need filter (unlock 未達の除外) ----------
+# ---------- standard need: observed 無関係に住民居れば加算 (#96) ----------
 
 
-def test_unlock_not_met_need_excluded_when_not_observed() -> None:
-    """``product_saturations`` に無い need は unlock 未達と見なし加算しない．
+def test_standard_needs_added_regardless_of_product_saturations() -> None:
+    """standard need は ``product_saturations`` に関係なく住民居れば加算 (#96)．
 
-    Calculator の Farmer tier には Fish と Biscuits 両方が候補として並ぶが
-    書記長の save で Biscuits が要求されてない (ConsumptionStates に未登録)
-    場合は消費に乗らない．
+    旧仕様: observed filter で saturation 観測済 need のみ加算 → 新世界 /
+    Scholars 等の need が消費 0 になる副作用．
+    新仕様 (#96): standard need は住民居れば全加算．bonus は除外継続．
+    正確な unlock gate は #99 で ``unlock_condition_guid`` ベースに再導入予定．
     """
     consumption = _mk_consumption(
         PopulationTier(
@@ -205,7 +207,7 @@ def test_unlock_not_met_need_excluded_when_not_observed() -> None:
             name="Farmers",
             needs=(
                 TierNeed(product_guid=200, tpmin=0.01),  # Fish: 観測済
-                TierNeed(product_guid=400, tpmin=0.02),  # Biscuits: 未観測 = unlock 外
+                TierNeed(product_guid=400, tpmin=0.02),  # Biscuits: 未観測でも加算される
             ),
         )
     )
@@ -213,21 +215,16 @@ def test_unlock_not_met_need_excluded_when_not_observed() -> None:
         _mk_residence(
             residents=100,
             tier_breakdown=(TierSummary(tier="farmer", residence_count=10, resident_total=100),),
-            observed_products=(200,),  # Fish のみ観測
+            observed_products=(200,),  # Fish のみ観測 — もう影響しない
         )
     ]
     table = build_balance_table(residences=residences, consumption=consumption)
     guids = {p.product_guid for p in table.islands[0].products}
-    assert 200 in guids
-    assert 400 not in guids
+    assert guids == {200, 400}
 
 
-def test_no_observed_products_falls_back_to_all_needs() -> None:
-    """``product_saturations`` 空なら tier.needs を全加算 (既存互換 fallback)．
-
-    都市再建直後など save に tier_breakdown だけあって ConsumptionStates が
-    populate されてないケースで 0 加算にならないようにする．
-    """
+def test_standard_needs_added_with_no_observations() -> None:
+    """``product_saturations`` 空でも standard need は加算 (旧 fallback と同等)．"""
     consumption = _mk_consumption(
         PopulationTier(
             guid=15000000,
@@ -242,12 +239,11 @@ def test_no_observed_products_falls_back_to_all_needs() -> None:
         _mk_residence(
             residents=100,
             tier_breakdown=(TierSummary(tier="farmer", residence_count=10, resident_total=100),),
-            observed_products=(),  # 観測ゼロ
+            observed_products=(),
         )
     ]
     table = build_balance_table(residences=residences, consumption=consumption)
     guids = {p.product_guid for p in table.islands[0].products}
-    # fallback: 両方の need が加算される
     assert guids == {200, 400}
 
 
@@ -378,3 +374,153 @@ def test_factories_on_island_without_recipe_do_not_crash() -> None:
     recipes = _mk_recipes()  # 空 table
     table = build_balance_table(residences=residences, factories=factories, recipes=recipes)
     assert table.islands[0].products == ()
+
+
+# ---------- 中間物資消費 (#96) ----------
+
+
+def test_intermediate_product_consumed_by_factory_inputs() -> None:
+    """缶詰肉工場が豚を消費する．豚の balance に消費が乗る．
+
+    旧仕様: 豚は生産 +5, 消費 0 → 大幅黒字 (虚像)．
+    新仕様 (#96): 缶詰肉工場の input から豚の消費を計上．
+    """
+    PIG = 200
+    CAN = 300
+    recipes = _mk_recipes(
+        FactoryRecipe(
+            guid=1,
+            name="Pig farm",
+            tpmin=2.0,
+            outputs=(RecipeOutput(product_guid=PIG, amount=1.0),),
+        ),
+        FactoryRecipe(
+            guid=2,
+            name="Cannery",
+            tpmin=1.0,
+            outputs=(RecipeOutput(product_guid=CAN, amount=1.0),),
+            inputs=(RecipeInput(product_guid=PIG, amount=1.5),),
+        ),
+    )
+    residences = [_mk_residence(am="A1", residents=0)]
+    factories = [
+        _mk_factory(
+            am="A1",
+            instances=(
+                FactoryInstance(building_guid=1, productivity=1.0),  # +2 pig/min
+                FactoryInstance(building_guid=2, productivity=1.0),  # -1.5 pig/min, +1 can/min
+            ),
+        )
+    ]
+    table = build_balance_table(residences=residences, factories=factories, recipes=recipes)
+    by_guid = {p.product_guid: p for p in table.islands[0].products}
+    pig = by_guid[PIG]
+    assert pig.produced_per_minute == pytest.approx(2.0)
+    assert pig.consumed_per_minute == pytest.approx(1.5)
+    assert pig.delta_per_minute == pytest.approx(0.5)
+    can = by_guid[CAN]
+    assert can.produced_per_minute == pytest.approx(1.0)
+    assert can.consumed_per_minute == 0.0
+
+
+def test_intermediate_consumption_combines_with_population_consumption() -> None:
+    """同一物資が住民にも工場入力にも消費される場合，両方加算される．"""
+    FISH = 200
+    consumption = _mk_consumption(
+        PopulationTier(
+            guid=15000000, name="Farmers", needs=(TierNeed(product_guid=FISH, tpmin=0.01),)
+        )
+    )
+    recipes = _mk_recipes(
+        FactoryRecipe(
+            guid=1,
+            name="Fish meal",
+            tpmin=1.0,
+            outputs=(RecipeOutput(product_guid=999, amount=1.0),),
+            inputs=(RecipeInput(product_guid=FISH, amount=2.0),),
+        )
+    )
+    residences = [
+        _mk_residence(
+            am="A1",
+            residents=100,
+            tier_breakdown=(TierSummary(tier="farmer", residence_count=10, resident_total=100),),
+        )
+    ]
+    factories = [
+        _mk_factory(am="A1", instances=(FactoryInstance(building_guid=1, productivity=1.0),))
+    ]
+    table = build_balance_table(
+        residences=residences, factories=factories, recipes=recipes, consumption=consumption
+    )
+    by_guid = {p.product_guid: p for p in table.islands[0].products}
+    fish = by_guid[FISH]
+    # 住民 100 × 0.01 + 工場 1 × 1.0 × 2.0 = 1.0 + 2.0 = 3.0
+    assert fish.consumed_per_minute == pytest.approx(3.0)
+
+
+def test_intermediate_consumption_scales_with_productivity() -> None:
+    """factory の productivity が input 消費にも反映される．"""
+    INPUT = 200
+    recipes = _mk_recipes(
+        FactoryRecipe(
+            guid=1,
+            name="Refinery",
+            tpmin=1.0,
+            outputs=(RecipeOutput(product_guid=999, amount=1.0),),
+            inputs=(RecipeInput(product_guid=INPUT, amount=1.0),),
+        )
+    )
+    residences = [_mk_residence(am="A1", residents=0)]
+    factories = [
+        _mk_factory(am="A1", instances=(FactoryInstance(building_guid=1, productivity=0.5),))
+    ]
+    table = build_balance_table(residences=residences, factories=factories, recipes=recipes)
+    by_guid = {p.product_guid: p for p in table.islands[0].products}
+    # 0.5 × 1.0 × 1.0 = 0.5
+    assert by_guid[INPUT].consumed_per_minute == pytest.approx(0.5)
+
+
+def test_intermediate_consumption_input_amount_none_defaults_to_one() -> None:
+    """``RecipeInput.amount = None`` は 1.0 として扱う (output 側と揃える)．"""
+    recipes = _mk_recipes(
+        FactoryRecipe(
+            guid=1,
+            name="Mystery factory",
+            tpmin=2.0,
+            outputs=(RecipeOutput(product_guid=999, amount=1.0),),
+            inputs=(RecipeInput(product_guid=200, amount=None),),
+        )
+    )
+    residences = [_mk_residence(am="A1", residents=0)]
+    factories = [
+        _mk_factory(am="A1", instances=(FactoryInstance(building_guid=1, productivity=1.0),))
+    ]
+    table = build_balance_table(residences=residences, factories=factories, recipes=recipes)
+    by_guid = {p.product_guid: p for p in table.islands[0].products}
+    # 1.0 × 2.0 × 1.0 (default amount) = 2.0
+    assert by_guid[200].consumed_per_minute == pytest.approx(2.0)
+
+
+# ---------- Tourists mapping (#96) ----------
+
+
+def test_tourist_tier_maps_to_consumption_table_tourists() -> None:
+    """``"tourist"`` tier key が consumption の ``Tourists`` を引ける (#96)．"""
+    consumption = _mk_consumption(
+        PopulationTier(
+            guid=999999, name="Tourists", needs=(TierNeed(product_guid=200, tpmin=0.01),)
+        )
+    )
+    residences = [
+        _mk_residence(
+            am="A1",
+            residents=50,
+            tier_breakdown=(TierSummary(tier="tourist", residence_count=5, resident_total=50),),
+        )
+    ]
+    table = build_balance_table(residences=residences, consumption=consumption)
+    p = table.islands[0].products[0]
+    assert p.product_guid == 200
+    # 50 × 0.01 = 0.5
+    assert p.consumed_per_minute == pytest.approx(0.5)

--- a/tests/trade/test_consumption.py
+++ b/tests/trade/test_consumption.py
@@ -95,6 +95,44 @@ def test_load_from_custom_data_dir(tmp_path: Path) -> None:
     assert table.display_name(100, "ja") == "おもちゃ"
 
 
+def test_unlock_condition_guid_default_is_none() -> None:
+    """``TierNeed.unlock_condition_guid`` は default ``None`` で，現状全 need が None．
+
+    schema slot は #99 で ``assets.xml`` 由来の値を埋める前提．今は全 None．
+    balance gate は将来の ``unlock_condition_guid`` ベースに切替予定．
+    """
+    need = TierNeed(product_guid=1)
+    assert need.unlock_condition_guid is None
+
+
+def test_unlock_condition_guid_round_trips_via_yaml(tmp_path: Path) -> None:
+    """YAML に ``unlock_condition_guid`` フィールドを書けば load 後保持される (将来 #99 用)．"""
+    _write_yaml(
+        tmp_path / "consumption_anno1800.en.yaml",
+        {
+            "tiers": [
+                {
+                    "guid": 100,
+                    "name": "Toy",
+                    "full_house": 4,
+                    "dlcs": [],
+                    "needs": [
+                        {
+                            "product_guid": 200,
+                            "tpmin": 0.01,
+                            "unlock_condition_guid": 999000,
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    table = ConsumptionTable.load(data_dir=tmp_path)
+    tier = table.get_tier(100)
+    assert tier is not None
+    assert tier.needs[0].unlock_condition_guid == 999000
+
+
 def test_load_without_ja_file_still_works(tmp_path: Path) -> None:
     """``ja`` YAML が無くても en だけで load できる．"""
     _write_yaml(

--- a/tests/trade/test_factory_recipes.py
+++ b/tests/trade/test_factory_recipes.py
@@ -91,6 +91,64 @@ def test_produced_per_minute_default_output_amount() -> None:
     assert r.produced_per_minute(1.0) == {100: pytest.approx(2.0)}
 
 
+# ---------- consumed_per_minute (#96) ----------
+
+
+def test_consumed_per_minute_basic() -> None:
+    """input 1 個，amount=1，tpmin=2，productivity=1 → 2 /min 消費．"""
+    r = FactoryRecipe(
+        guid=1,
+        name="Cannery",
+        tpmin=2.0,
+        inputs=(RecipeInput(product_guid=400, amount=1.0),),
+    )
+    assert r.consumed_per_minute(1.0) == {400: pytest.approx(2.0)}
+    assert r.consumed_per_minute(0.5) == {400: pytest.approx(1.0)}
+
+
+def test_consumed_per_minute_multi_input() -> None:
+    """複数 input を別 product として加算．"""
+    r = FactoryRecipe(
+        guid=1,
+        name="Steel",
+        tpmin=1.0,
+        inputs=(
+            RecipeInput(product_guid=400, amount=1.0),
+            RecipeInput(product_guid=500, amount=2.0),
+        ),
+    )
+    out = r.consumed_per_minute(1.0)
+    assert out == {400: pytest.approx(1.0), 500: pytest.approx(2.0)}
+
+
+def test_consumed_per_minute_no_inputs_returns_empty() -> None:
+    """input 0 個 (raw extractor) は空 dict．"""
+    r = FactoryRecipe(guid=1, name="Hunter", tpmin=2.0)
+    assert r.consumed_per_minute(1.0) == {}
+
+
+def test_consumed_per_minute_missing_tpmin() -> None:
+    """tpmin 未定義なら空．"""
+    r = FactoryRecipe(
+        guid=1,
+        name="F",
+        tpmin=None,
+        inputs=(RecipeInput(product_guid=400, amount=1.0),),
+    )
+    assert r.consumed_per_minute(1.0) == {}
+
+
+def test_consumed_per_minute_default_input_amount() -> None:
+    """input.amount が None の場合は 1.0 とみなす (output 側と揃える)．"""
+    r = FactoryRecipe(
+        guid=1,
+        name="F",
+        tpmin=2.0,
+        inputs=(RecipeInput(product_guid=400, amount=None),),
+    )
+    assert r.consumed_per_minute(1.0) == {400: pytest.approx(2.0)}
+
+
 # ---------- 合成 YAML ----------
 
 


### PR DESCRIPTION
## Summary

Closes #96.

Three behaviour fixes so the supply balance matches what players observe in-game:

1. **Intermediate products are now deducted** as factory inputs. ``FactoryRecipe.consumed_per_minute()`` (new, symmetric to existing ``produced_per_minute``) + ``_consumed_intermediate_for_island`` aggregate input consumption from every factory instance on the island.
2. **Standard needs always add up** when residents are present. The old ``product_saturations``-based filter was too strict and silently dropped New-World / Arctic / Enbesa / Scholars needs that had no observed consumption sample. Bonus needs remain excluded by default — the precise unlock gate returns via ``unlock_condition_guid`` (#99).
3. **Tourists tier resolves**: added ``"tourist": "Tourists"`` to ``_TIER_KEY_TO_CONSUMPTION_NAME``.

Also opens an optional ``TierNeed.unlock_condition_guid`` field (currently always ``None``) so #99 can populate it without re-modelling later.

## Test plan

- [x] ``tests/trade/test_balance.py`` — 3 intermediate-product cases, 1 Tourists case, rewrite of observed-filter tests
- [x] ``tests/trade/test_factory_recipes.py`` — 5 ``consumed_per_minute`` cases
- [x] ``tests/trade/test_consumption.py`` — 2 ``unlock_condition_guid`` schema cases
- [x] Full suite: 700 passed locally (+30 skipped sample-dependent smoke tests; CI will run them)
- [x] ``ruff check`` + ``ruff format --check`` clean

## Out of scope

- bonus-need per-residence ON/OFF reflection → #97
- ``UnlockCondition`` extraction from ``assets.xml`` → #99