### PR TITLE
fix(tui): pass state.locale to FactoryRecipeTable.load so factory names use ja YAML

### DIFF
--- a/src/anno_save_analyzer/tui/screens/production_overview.py
+++ b/src/anno_save_analyzer/tui/screens/production_overview.py
@@ -92,8 +92,9 @@ class ProductionOverviewScreen(Screen):
         # 現在 Tree で選択中の filter．None = All．それ以外は (kind, value)．
         self._filter: tuple[str, str] | None = None
         # FactoryRecipeTable を 1 度だけ load (失敗時 None)．Anno 1800 以外は
-        # データが無いので空テーブル相当で表示するフォールバック．
-        self._recipes: FactoryRecipeTable | None = self._try_load_recipes()
+        # データが無いので空テーブル相当で表示するフォールバック．state.locale を
+        # 渡して factory 名を日本語化 (#102)．
+        self._recipes: FactoryRecipeTable | None = self._try_load_recipes(state.locale)
         # building_guid → recipe を直接引けるように cache．
         self._recipe_by_guid: dict[int, FactoryRecipe] = (
             dict(self._recipes.recipes) if self._recipes is not None else {}
@@ -102,9 +103,10 @@ class ProductionOverviewScreen(Screen):
         self._last_detail_row: tuple[str, int] | None = None
 
     @staticmethod
-    def _try_load_recipes() -> FactoryRecipeTable | None:
+    def _try_load_recipes(locale: str) -> FactoryRecipeTable | None:
+        recipe_locales = ("en",) if locale == "en" else ("en", locale)
         try:
-            return FactoryRecipeTable.load()
+            return FactoryRecipeTable.load(locales=recipe_locales)
         except (FileNotFoundError, ValueError):  # pragma: no cover - defensive
             return None
 

--- a/src/anno_save_analyzer/tui/state.py
+++ b/src/anno_save_analyzer/tui/state.py
@@ -217,7 +217,9 @@ def load_state(
     )
 
     progress("computing supply balance")
-    balance_table, am_to_session_key = _try_build_balance_table(title, inner_payloads, buildings)
+    balance_table, am_to_session_key = _try_build_balance_table(
+        title, inner_payloads, buildings, locale=locale
+    )
     # Jaccard match 成功した AM → city_name map (label 分類用)．
     am_to_city: dict[str, str] = {m.area_manager: m.city_name for m in city_area_matches}
 
@@ -330,17 +332,22 @@ def _try_build_balance_table(
     title: GameTitle,
     inner_payloads: list[bytes],
     buildings: BuildingDictionary | None,
+    locale: str = "en",
 ) -> tuple[SupplyBalanceTable | None, dict[str, str]]:
     """Anno 1800 + BuildingDictionary 有り の時だけ supply balance を算出．
+
+    ``locale`` は ``FactoryRecipeTable.load(locales=...)`` に渡して工場名を
+    日本語等に解決させる．未指定なら英語のみ (#102 の locale 透過)．
 
     返り値は ``(balance_table, area_manager → session_locale_key)`` のタプル．
     後者は UI 側で「どの session の島か」を表示するのに使う．
     """
     if title is not GameTitle.ANNO_1800 or buildings is None:
         return None, {}
+    recipe_locales = ("en",) if locale == "en" else ("en", locale)
     try:
         consumption = ConsumptionTable.load()
-        recipes = FactoryRecipeTable.load()
+        recipes = FactoryRecipeTable.load(locales=recipe_locales)
     except (FileNotFoundError, ValueError):  # pragma: no cover - defensive
         return None, {}
     all_residences: list[ResidenceAggregate] = []

--- a/tests/tui/test_production_overview.py
+++ b/tests/tui/test_production_overview.py
@@ -85,7 +85,7 @@ def tui_state_with_factories(tui_state, monkeypatch) -> TuiState:
     """
     monkeypatch.setattr(
         "anno_save_analyzer.tui.screens.production_overview.FactoryRecipeTable.load",
-        classmethod(lambda cls: _make_recipe_table()),
+        classmethod(lambda cls, *, locales=("en",): _make_recipe_table()),
     )
     return dataclasses.replace(
         tui_state,
@@ -297,7 +297,7 @@ class TestProductionRecipeFallbacks:
 
         monkeypatch.setattr(
             "anno_save_analyzer.tui.screens.production_overview.FactoryRecipeTable.load",
-            classmethod(lambda cls: FactoryRecipeTable(recipes={})),
+            classmethod(lambda cls, *, locales=("en",): FactoryRecipeTable(recipes={})),
         )
         unknown_state = dataclasses.replace(
             tui_state,
@@ -322,6 +322,56 @@ class TestProductionRecipeFallbacks:
             assert "Building_999999" in row[0]
             assert row[3] == "—"
             assert row[4] == "0.00"
+
+
+class TestProductionRecipeLocalePassthrough:
+    """``state.locale`` が ``FactoryRecipeTable.load`` に届くこと (#102)．"""
+
+    def test_load_called_with_state_locale_ja(self, tui_state, monkeypatch) -> None:
+        """state.locale="ja" で screen を作ると ``locales=("en", "ja")`` が渡る．"""
+        captured: dict[str, object] = {}
+
+        def fake_load(cls, *, locales=("en",)):
+            captured["locales"] = locales
+            return _make_recipe_table()
+
+        monkeypatch.setattr(
+            "anno_save_analyzer.tui.screens.production_overview.FactoryRecipeTable.load",
+            classmethod(fake_load),
+        )
+        ja_state = dataclasses.replace(
+            tui_state,
+            locale="ja",
+            title=GameTitle.ANNO_1800,
+            factories_by_island=_make_factories_by_island(),
+        )
+        from anno_save_analyzer.tui.i18n import Localizer
+
+        ProductionOverviewScreen(ja_state, Localizer.load("ja"))
+        assert captured["locales"] == ("en", "ja")
+
+    def test_load_called_with_en_only_when_locale_en(self, tui_state, monkeypatch) -> None:
+        """state.locale="en" なら冗長な ja YAML を読まないよう ``("en",)`` のみ．"""
+        captured: dict[str, object] = {}
+
+        def fake_load(cls, *, locales=("en",)):
+            captured["locales"] = locales
+            return _make_recipe_table()
+
+        monkeypatch.setattr(
+            "anno_save_analyzer.tui.screens.production_overview.FactoryRecipeTable.load",
+            classmethod(fake_load),
+        )
+        en_state = dataclasses.replace(
+            tui_state,
+            locale="en",
+            title=GameTitle.ANNO_1800,
+            factories_by_island=_make_factories_by_island(),
+        )
+        from anno_save_analyzer.tui.i18n import Localizer
+
+        ProductionOverviewScreen(en_state, Localizer.load("en"))
+        assert captured["locales"] == ("en",)
 
 
 class TestProductionRateCalculation:

--- a/tests/tui/test_state.py
+++ b/tests/tui/test_state.py
@@ -215,6 +215,48 @@ class TestCollectFactoriesByIsland:
         assert "AreaManager_99" in result
 
 
+class TestTryBuildBalanceTableLocale:
+    """``_try_build_balance_table`` が ``FactoryRecipeTable.load`` に locale を透過する (#102)．"""
+
+    def test_locale_ja_passes_en_ja_locales(self, monkeypatch) -> None:
+        from anno_save_analyzer.trade.buildings import BuildingDictionary
+        from anno_save_analyzer.tui import state as state_mod
+
+        captured: dict[str, object] = {}
+
+        def fake_recipe_load(cls, *, locales=("en",)):
+            captured["recipe_locales"] = locales
+            return state_mod.FactoryRecipeTable(recipes={})
+
+        def fake_consumption_load(cls, *, data_dir=None):
+            return state_mod.ConsumptionTable(tiers=())
+
+        monkeypatch.setattr(state_mod.FactoryRecipeTable, "load", classmethod(fake_recipe_load))
+        monkeypatch.setattr(state_mod.ConsumptionTable, "load", classmethod(fake_consumption_load))
+        bd = BuildingDictionary(entries={})
+        state_mod._try_build_balance_table(GameTitle.ANNO_1800, [], bd, locale="ja")
+        assert captured["recipe_locales"] == ("en", "ja")
+
+    def test_locale_en_passes_en_only(self, monkeypatch) -> None:
+        from anno_save_analyzer.trade.buildings import BuildingDictionary
+        from anno_save_analyzer.tui import state as state_mod
+
+        captured: dict[str, object] = {}
+
+        def fake_recipe_load(cls, *, locales=("en",)):
+            captured["recipe_locales"] = locales
+            return state_mod.FactoryRecipeTable(recipes={})
+
+        def fake_consumption_load(cls, *, data_dir=None):
+            return state_mod.ConsumptionTable(tiers=())
+
+        monkeypatch.setattr(state_mod.FactoryRecipeTable, "load", classmethod(fake_recipe_load))
+        monkeypatch.setattr(state_mod.ConsumptionTable, "load", classmethod(fake_consumption_load))
+        bd = BuildingDictionary(entries={})
+        state_mod._try_build_balance_table(GameTitle.ANNO_1800, [], bd, locale="en")
+        assert captured["recipe_locales"] == ("en",)
+
+
 class TestLoadInnerSessionsHelper:
     def test_reads_a8s_via_extract_inner_filedb(
         self, tmp_path: Path, tui_state, monkeypatch


### PR DESCRIPTION
## Summary

Closes #102.

The TUI production overview rendered factory names in English even when launched with ``--locale ja`` because two ``FactoryRecipeTable.load()`` call sites did not forward the locale:

- ``tui/state.py`` ``_try_build_balance_table`` (used by supply balance)
- ``tui/screens/production_overview.py`` ``_try_load_recipes``

Both now pass ``locales=("en", state.locale)`` so the existing ``factory_recipes_anno1800.ja.yaml`` (219 entries, already complete) overrides the English names.

## Test plan

- [x] ``tests/tui/test_state.py``: 2 new tests asserting ``recipe_locales == ("en", "ja")`` for ``locale=ja`` and ``("en",)`` for ``locale=en``
- [x] ``tests/tui/test_production_overview.py``: 2 new screen-level tests + existing fallback monkeypatches updated to accept new ``locales=`` kwarg
- [x] 719 passed locally
- [x] ``ruff check`` + ``ruff format --check`` clean