### PR TITLE
fix(buildings): map all DLC residence tiers in generator (Jornaleros..Tourists)

### DIFF
--- a/scripts/generate_buildings_anno1800.py
+++ b/scripts/generate_buildings_anno1800.py
@@ -62,7 +62,12 @@ _KIND_RULES: tuple[tuple[str, str], ...] = (
     ("VisitorPier", "pier"),
 )
 
-# Residence tier 番号 → 正規 tier key．Anno 1800 は 5 tier (+ DLC で 6, 7)．
+# Residence tier 番号 → 正規 tier key．
+#
+# 旧世界 (base game) は ``residence_tier01`` ～ ``residence_tier05`` で
+# farmer / worker / artisan / engineer / investor の 5 tier．DLC で追加された
+# 新世界 / Hacienda / 北極圏 / エンベサ / Hotel / Skyline Tower 等は別系列の
+# internal_name を持つため，個別の regex / mapping で拾う必要がある (#103)．
 _RES_TIER_RE = re.compile(r"residence_tier(\d{2})")
 _TIER_KEY = {
     1: "farmer",
@@ -70,10 +75,29 @@ _TIER_KEY = {
     3: "artisan",
     4: "engineer",
     5: "investor",
-    # DLC
-    6: "jornaleros",
-    7: "obreros",
 }
+
+# 新世界 (Caribbean) — residence_colony01_tier01..03
+_COLONY01_RE = re.compile(r"residence_colony01_tier(\d{2})")
+_COLONY01_TIER = {1: "jornaleros", 2: "obreros", 3: "artista"}
+
+# Hacienda residence module (Tourist Season DLC) — 同 tier set
+_HACIENDA_RE = re.compile(r"hacienda residence module tier(\d{2})")
+_HACIENDA_TIER = _COLONY01_TIER
+
+# 北極圏 (The Passage DLC)
+_ARCTIC_RE = re.compile(r"residence_arctic_tier(\d{2})")
+_ARCTIC_TIER = {1: "explorer", 2: "technician"}
+
+# エンベサ (Land of Lions DLC) — colony02．scholar (tier3) は SOC DLC 用に予約．
+_COLONY02_RE = re.compile(r"residence_colony02_tier(\d{2})")
+_COLONY02_TIER = {1: "shepherd", 2: "elder", 3: "scholar"}
+
+# 名前ベース mapping — Hotel (Tourist Season DLC) と Skyline Tower (High Life DLC)．
+_NAME_TIER: tuple[tuple[str, str], ...] = (
+    ("hotel", "tourist"),
+    ("highlife_monument", "investor"),
+)
 
 
 def _kind_for(template: str) -> str | None:
@@ -84,10 +108,33 @@ def _kind_for(template: str) -> str | None:
 
 
 def _tier_for(internal_name: str) -> str | None:
-    match = _RES_TIER_RE.search(internal_name.lower())
-    if not match:
-        return None
-    return _TIER_KEY.get(int(match.group(1)))
+    """Residence の internal_name から tier key を推定する．
+
+    順に: 旧世界 / 新世界 (colony01) / Hacienda module / 北極圏 (arctic) /
+    エンベサ (colony02) / 名前ベース (Hotel, Skyline Tower) を試す．
+    どれにも合致しなければ ``None``．
+    """
+    lower = internal_name.lower()
+    match = _RES_TIER_RE.search(lower)
+    if match:
+        tier = _TIER_KEY.get(int(match.group(1)))
+        if tier is not None:
+            return tier
+    for regex, table in (
+        (_COLONY01_RE, _COLONY01_TIER),
+        (_HACIENDA_RE, _HACIENDA_TIER),
+        (_ARCTIC_RE, _ARCTIC_TIER),
+        (_COLONY02_RE, _COLONY02_TIER),
+    ):
+        match = regex.search(lower)
+        if match:
+            tier = table.get(int(match.group(1)))
+            if tier is not None:
+                return tier
+    for needle, tier_key in _NAME_TIER:
+        if needle in lower:
+            return tier_key
+    return None
 
 
 def extract_buildings(config_data: bytes) -> list[dict[str, Any]]:

--- a/scripts/generate_buildings_anno1800.py
+++ b/scripts/generate_buildings_anno1800.py
@@ -9,7 +9,14 @@ MVP 範囲:
 - name (en/ja) — texts_<lang>.xml から GUID-direct lookup (items と同パターン)
 - kind — ``residence`` / ``factory`` / ``farm`` / ``warehouse`` /
   ``public_service`` / ``buff_factory``
-- tier — Residence のみ．internal Name ``residence_tier0N`` から 1..7 を推定
+- tier — Residence のみ．internal Name から 6 系列の判定で正規化:
+
+  * 旧世界  ``residence_tier01..05`` → farmer / worker / artisan / engineer / investor
+  * 新世界  ``residence_colony01_tier01..03`` → jornaleros / obreros / artista
+  * Hacienda  ``Hacienda residence module tier01..03`` → 同 (jornaleros / obreros / artista)
+  * 北極  ``residence_arctic_tier01..02`` → explorer / technician
+  * エンベサ  ``residence_colony02_tier01..03`` → shepherd / elder / scholar (3 は SOC DLC，未確認時は予約)
+  * 単独建物  ``Hotel`` → tourist，``HighLife_monument_*(residence)`` (Skyline Tower) → investor
 
 **非 MVP**: workforce_provided / workforce_required / inputs / outputs /
 production chain は別 issue (#66, #12) で FactoryBase / ProductionChain

--- a/src/anno_save_analyzer/data/buildings_anno1800.en.yaml
+++ b/src/anno_save_analyzer/data/buildings_anno1800.en.yaml
@@ -6,6 +6,7 @@
   name: "Skyline Tower"
   kind: residence
   template: "ResidenceBuilding-Unique"
+  tier: investor
 2397:
   name: "Furnace"
   kind: factory
@@ -30,6 +31,7 @@
   name: "Artista Residence"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: artista
 5457:
   name: "Nandu Farm"
   kind: farm
@@ -130,6 +132,7 @@
   name: "Hacienda Artista Quarters"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: artista
 6264:
   name: "Beach"
   kind: buff_factory
@@ -262,10 +265,12 @@
   name: "Hacienda Jornalero Quarters"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: jornaleros
 24793:
   name: "Hacienda Obrera Quarters"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: obreros
 24794:
   name: "Hacienda Farm"
   kind: farm
@@ -486,10 +491,12 @@
   name: "Jornalero Residence"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: jornaleros
 101255:
   name: "Obrero Residence"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: obreros
 101258:
   name: "Chapel"
   kind: public_service
@@ -570,10 +577,12 @@
   name: "Explorer Shelter"
   kind: residence
   template: "ResidenceBuilding7_Arctic"
+  tier: explorer
 112652:
   name: "Technician Shelter"
   kind: residence
   template: "ResidenceBuilding7_Arctic"
+  tier: technician
 112666:
   name: "Whaling Station"
   kind: factory
@@ -638,10 +647,12 @@
   name: "Shepherd Residence"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: shepherd
 114437:
   name: "Elder Residence"
   kind: residence
   template: "ResidenceBuilding7_Colony"
+  tier: elder
 114439:
   name: "Sanga Farm"
   kind: farm
@@ -955,6 +966,7 @@
   name: "Hotel"
   kind: residence
   template: "ResidenceBuilding7_Hotel"
+  tier: tourist
 601882:
   name: "Investor Skyscraper: Level 1"
   kind: residence

--- a/src/anno_save_analyzer/trade/buildings.py
+++ b/src/anno_save_analyzer/trade/buildings.py
@@ -52,8 +52,10 @@ class BuildingEntry(BaseModel):
     """元 assets.xml の ``<Template>`` 値．細分種別 (``ResidenceBuilding7_Arctic``
     等) を見たい場合はこちらを参照．"""
     tier: str | None = None
-    """Residence のみ．``farmer`` / ``worker`` / ``artisan`` / ``engineer``
-    / ``investor`` / ``jornaleros`` / ``obreros``．判定不能で未設定の可能性もある．"""
+    """Residence のみ．旧世界 ``farmer`` / ``worker`` / ``artisan`` / ``engineer``
+    / ``investor``，新世界 ``jornaleros`` / ``obreros`` / ``artista``，北極圏
+    ``explorer`` / ``technician``，エンベサ ``shepherd`` / ``elder`` /
+    ``scholar``，観光客 ``tourist``．判定不能で未設定の可能性もある．"""
 
     model_config = {"frozen": True}
 

--- a/tests/trade/test_balance.py
+++ b/tests/trade/test_balance.py
@@ -524,3 +524,47 @@ def test_tourist_tier_maps_to_consumption_table_tourists() -> None:
     assert p.product_guid == 200
     # 50 × 0.01 = 0.5
     assert p.consumed_per_minute == pytest.approx(0.5)
+
+
+# ---------- DLC tier mapping (#103) ----------
+
+
+@pytest.mark.parametrize(
+    ("tier_key", "consumption_name"),
+    [
+        ("jornaleros", "Jornaleros"),
+        ("obreros", "Obreros"),
+        ("artista", "Artista"),
+        ("explorer", "Explorers"),
+        ("technician", "Technicians"),
+        ("shepherd", "Shepherds"),
+        ("elder", "Elders"),
+        ("scholar", "Scholars"),
+    ],
+)
+def test_dlc_tier_keys_route_consumption(tier_key: str, consumption_name: str) -> None:
+    """generator が出す DLC tier key が ``ConsumptionTable`` 側の英語名で引ける (#103)．
+
+    ``buildings_anno1800.yaml`` の tier フィールドに 12 件の DLC residence が
+    乗ったあと，それらの住民消費が balance に乗ることを保証する．
+    旧仕様 (#103 修正前) は tier=None で全住民消費が 0 扱いになっていた．
+    """
+    consumption = _mk_consumption(
+        PopulationTier(
+            guid=15000000 + hash(tier_key) % 1000000,
+            name=consumption_name,
+            needs=(TierNeed(product_guid=200, tpmin=0.01),),
+        )
+    )
+    residences = [
+        _mk_residence(
+            am="A1",
+            residents=200,
+            tier_breakdown=(TierSummary(tier=tier_key, residence_count=20, resident_total=200),),
+        )
+    ]
+    table = build_balance_table(residences=residences, consumption=consumption)
+    products = table.islands[0].products
+    assert len(products) == 1, f"tier={tier_key!r} did not route consumption"
+    # 200 × 0.01 = 2.0
+    assert products[0].consumed_per_minute == pytest.approx(2.0)

--- a/tests/trade/test_buildings.py
+++ b/tests/trade/test_buildings.py
@@ -17,8 +17,13 @@ def _load_generator_module():
     `scripts/` は Python package ではないので importlib で直接 spec から読む．
     依存している `generate_items_anno1800` も同じディレクトリで隣接 import
     されるので，先に sys.path に scripts/ を入れる．
+
+    終了時は ``sys.path`` をスナップショットから完全復元する (generator 自身が
+    ``sys.path.insert`` するため，1 件 ``remove`` だけだと後続テストに副作用が
+    残る — Copilot 指摘 PR #106)．
     """
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    saved_path = list(sys.path)
     sys.path.insert(0, str(scripts_dir))
     try:
         spec = importlib.util.spec_from_file_location(
@@ -30,7 +35,7 @@ def _load_generator_module():
         spec.loader.exec_module(module)
         return module
     finally:
-        sys.path.remove(str(scripts_dir))
+        sys.path[:] = saved_path
 
 
 # ---------- 実データ smoke ----------

--- a/tests/trade/test_buildings.py
+++ b/tests/trade/test_buildings.py
@@ -2,11 +2,36 @@
 
 from __future__ import annotations
 
+import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
 
 from anno_save_analyzer.trade.buildings import BuildingDictionary, known_kinds
+
+
+def _load_generator_module():
+    """scripts/generate_buildings_anno1800.py を package 外から import する．
+
+    `scripts/` は Python package ではないので importlib で直接 spec から読む．
+    依存している `generate_items_anno1800` も同じディレクトリで隣接 import
+    されるので，先に sys.path に scripts/ を入れる．
+    """
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "generate_buildings_anno1800",
+            scripts_dir / "generate_buildings_anno1800.py",
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(scripts_dir))
+
 
 # ---------- 実データ smoke ----------
 
@@ -184,3 +209,58 @@ def test_invalid_yaml_root_in_locale_raises_value_error(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="buildings_anno1800.ja.yaml"):
         BuildingDictionary.load(data_dir=tmp_path, locales=("ja", "en"))
+
+
+# ---------- generator `_tier_for` パターン別テスト (#103) ----------
+
+
+@pytest.mark.parametrize(
+    ("internal_name", "expected_tier"),
+    [
+        # 旧世界 (base game) — 既存挙動の保証
+        ("residence_tier01", "farmer"),
+        ("residence_tier02", "worker"),
+        ("residence_tier03", "artisan"),
+        ("residence_tier04", "engineer"),
+        ("residence_tier05", "investor"),
+        # 新世界 (Caribbean) colony01
+        ("residence_colony01_tier01", "jornaleros"),
+        ("residence_colony01_tier02", "obreros"),
+        ("residence_colony01_tier03", "artista"),
+        # Hacienda residence module (Tourist Season DLC)．大文字混在もケースして
+        # `.lower()` で吸収できることを確認．
+        ("Hacienda residence module tier01", "jornaleros"),
+        ("Hacienda residence module tier02", "obreros"),
+        ("Hacienda residence module tier03", "artista"),
+        # 北極圏 (The Passage DLC)
+        ("residence_arctic_tier01", "explorer"),
+        ("residence_arctic_tier02", "technician"),
+        # エンベサ (Land of Lions DLC) colony02．scholar (tier3) は
+        # SOC DLC の asset で確認できないが mapping は予約．
+        ("residence_colony02_tier01", "shepherd"),
+        ("residence_colony02_tier02", "elder"),
+        ("residence_colony02_tier03", "scholar"),
+        # 名前ベース — Hotel と Skyline Tower
+        ("Hotel", "tourist"),
+        ("HighLife_monument_03(residence)", "investor"),
+    ],
+)
+def test_generator_tier_for_resolves_dlc_residences(internal_name: str, expected_tier: str) -> None:
+    """``_tier_for`` が 6 系列すべての residence pattern で tier を返す (#103)．"""
+    module = _load_generator_module()
+    assert module._tier_for(internal_name) == expected_tier
+
+
+@pytest.mark.parametrize(
+    "internal_name",
+    [
+        "factory_lumberjack_01",  # residence でない
+        "residence_tier99",  # 旧世界 mapping 範囲外
+        "",  # 空文字
+        "warehouse_01",  # 名前 needle に当たらない
+    ],
+)
+def test_generator_tier_for_returns_none_when_no_match(internal_name: str) -> None:
+    """どの pattern にも一致しなければ ``None`` を返す．"""
+    module = _load_generator_module()
+    assert module._tier_for(internal_name) is None


### PR DESCRIPTION
## 概要

旧世界の ``residence_tier0N`` のみに対応していた ``scripts/generate_buildings_anno1800.py`` の ``_tier_for`` を 6 系列に拡張．12 件の DLC residence asset (新世界 / Hacienda / 北極圏 / エンベサ / Hotel / Skyline Tower) が ``tier=None`` 扱いだったのを正規 tier key にマップする．

これまで ``balance`` で新世界 / 北極圏 / エンベサ / Tourists 在住住民の standard need が消費 0 として落ちていた問題を修正する．Decision Matrix の ``increase_production`` が DLC tier 慢性赤字を正しく拾えるようになる．

## 変更内容

- ``scripts/generate_buildings_anno1800.py``
  - 旧世界 (base) の ``residence_tier0N`` から farmer..investor の 5 mapping のみ残す (base game の意味を厳密化)
  - 新世界 ``residence_colony01_tier0N`` → jornaleros / obreros / artista
  - Hacienda residence module ``hacienda residence module tier0N`` → 同 colony01 set
  - 北極圏 ``residence_arctic_tier0N`` → explorer / technician
  - エンベサ ``residence_colony02_tier0N`` → shepherd / elder / scholar (tier3 は SOC DLC 用に予約)
  - 名前ベース ``Hotel`` → tourist，``HighLife_monument`` → investor (Skyline Tower)
- ``buildings_anno1800.en.yaml`` を Anno 1800 install から再生成．12 件に ``tier`` フィールド追加 (詳細 diff は issue #103 の census 表どおり)．
- ``trade/buildings.py``: ``BuildingEntry.tier`` docstring を更新して新 tier 集合を明記
- ``tests/trade/test_buildings.py``: ``_tier_for`` の pattern 別 parametrized unit test (旧世界 5 + DLC 12 + 非該当 4) を追加
- ``tests/trade/test_balance.py``: 8 つの DLC tier key が ``ConsumptionTable`` 側の英語名 (Jornaleros..Scholars) に解決され消費が乗ることを確認する integration test を追加

## Test plan

- [x] ``ruff check src tests`` 通る
- [x] ``ruff format --check src tests`` 通る
- [x] ``pytest`` 全 745 件 pass，coverage 93.27% (>= 90% 維持)
- [x] ``buildings_anno1800.en.yaml`` の diff が issue #103 census 表どおり 12 件 + 行
- [ ] (要 manual 確認) 書記長セーブで ``diagnose`` 再実行時に新世界 / 北極 / エンベサの住民が要求する物資が balance に出る

Closes #103